### PR TITLE
feat(models): add refresh button to fetch latest OpenRouter models

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -69,7 +69,7 @@ from .council import (
     stage3_synthesize_final,
 )
 from .export import export_to_json, export_to_markdown
-from .models import fetch_available_models
+from .models import fetch_available_models, invalidate_cache as invalidate_models_cache
 from .websearch import get_search_provider, is_web_search_available
 
 app = FastAPI(title="LLM Council API")
@@ -299,6 +299,18 @@ async def get_available_models():
     """Get list of available models from OpenRouter."""
     models = await fetch_available_models()
     return {"models": models}
+
+
+@app.post("/api/models/refresh")
+async def refresh_available_models():
+    """Refresh the available models list from OpenRouter.
+
+    Invalidates the cache and fetches fresh data from the API.
+    Use this when new models are available on OpenRouter.
+    """
+    invalidate_models_cache()
+    models = await fetch_available_models()
+    return {"models": models, "refreshed": True}
 
 
 @app.post("/api/attachments")

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -72,6 +72,20 @@ export const api = {
   },
 
   /**
+   * Refresh available models from OpenRouter (invalidates cache).
+   * Use this to fetch the latest models when new models are available.
+   */
+  async refreshModels() {
+    const response = await fetch(`${API_BASE}/api/models/refresh`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      throw new Error('Failed to refresh models');
+    }
+    return response.json();
+  },
+
+  /**
    * Get curated models list.
    */
   async getCuratedModels() {

--- a/frontend/src/components/ModelCuration.css
+++ b/frontend/src/components/ModelCuration.css
@@ -110,8 +110,8 @@
 
 .curation-results {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: var(--space-md);
   font-size: 0.875rem;
   color: var(--color-text-secondary);
   font-family: var(--font-mono);
@@ -123,6 +123,46 @@
   gap: var(--space-xs);
   color: var(--color-burgundy);
   font-weight: 500;
+}
+
+.curation-results .refresh-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--color-ivory);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.curation-results .refresh-btn:hover:not(:disabled) {
+  background: var(--color-parchment);
+  border-color: var(--color-burgundy);
+  color: var(--color-burgundy);
+}
+
+.curation-results .refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.curation-results .refresh-btn.refreshing svg {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Override model-groups height for modal context */

--- a/frontend/src/components/ModelCuration.jsx
+++ b/frontend/src/components/ModelCuration.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { X, Star } from 'lucide-react';
+import { X, Star, RefreshCw } from 'lucide-react';
 import { useModels, useCuratedModels, useModelFiltering, useExpandableGroups } from '../hooks';
 import { ModelSearchBox, FilterChips, ModelGroups } from './models/index.js';
 import './ModelCuration.css';
@@ -10,7 +10,7 @@ import './ModelCuration.css';
  */
 export default function ModelCuration({ onClose, onSave }) {
   // Fetch models
-  const { models, loading, error: modelsError, refetch } = useModels();
+  const { models, loading, refreshing, error: modelsError, refetch, refresh } = useModels();
 
   // Curated models state
   const curated = useCuratedModels();
@@ -157,6 +157,15 @@ export default function ModelCuration({ onClose, onSave }) {
             <span className="curated-count">
               <Star size={14} /> {curatedIds.size} curated
             </span>
+            <button
+              className={`refresh-btn ${refreshing ? 'refreshing' : ''}`}
+              onClick={refresh}
+              disabled={refreshing}
+              title="Refresh models from OpenRouter"
+            >
+              <RefreshCw size={14} />
+              {refreshing ? 'Refreshing...' : 'Refresh'}
+            </button>
           </div>
 
           <ModelGroups

--- a/frontend/src/components/ModelSelector.css
+++ b/frontend/src/components/ModelSelector.css
@@ -124,11 +124,56 @@
   border-color: var(--color-burgundy);
 }
 
+.filter-results-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
 .filter-results-count {
   font-size: 0.875rem;
   color: var(--color-text-secondary);
-  margin-bottom: 12px;
   font-family: var(--font-mono);
+}
+
+.refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--color-ivory);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: var(--color-parchment);
+  border-color: var(--color-burgundy);
+  color: var(--color-burgundy);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.refresh-btn.refreshing svg {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .model-selector-loading,

--- a/frontend/src/components/ModelSelector.jsx
+++ b/frontend/src/components/ModelSelector.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { useModels, useCuratedModels, useModelFiltering, useExpandableGroups } from '../hooks';
 import { formatPrice, getDisplayName } from '../lib/models';
 import { ModelSearchBox, FilterChips, ModelGroups } from './models/index.js';
@@ -18,7 +19,7 @@ export default function ModelSelector({
   const [saving, setSaving] = useState(false);
 
   // Fetch models and curated list
-  const { models, loading, error, refetch } = useModels();
+  const { models, loading, refreshing, error, refetch, refresh } = useModels();
   const { curatedIds, loading: curatedLoading } = useCuratedModels();
 
   // Filtering with curated default
@@ -130,8 +131,19 @@ export default function ModelSelector({
           showContextFilter={true}
         />
 
-        <div className="filter-results-count">
-          {filteredCount} of {totalCount} models
+        <div className="filter-results-row">
+          <div className="filter-results-count">
+            {filteredCount} of {totalCount} models
+          </div>
+          <button
+            className={`refresh-btn ${refreshing ? 'refreshing' : ''}`}
+            onClick={refresh}
+            disabled={refreshing}
+            title="Refresh models from OpenRouter"
+          >
+            <RefreshCw size={14} />
+            {refreshing ? 'Refreshing...' : 'Refresh'}
+          </button>
         </div>
 
         <ModelGroups


### PR DESCRIPTION
Add ability to manually refresh the model list from OpenRouter API,
bypassing the 1-hour cache. This allows users to immediately see newly
available models without restarting the server.

Changes:
- Backend: Add POST /api/models/refresh endpoint that invalidates cache
- Frontend: Add refreshModels() API function
- Frontend: Add refreshing state and refresh() function to useModels hook
- Frontend: Add refresh button with spinning animation to ModelSelector
- Frontend: Add refresh button to ModelCuration modal

https://claude.ai/code/session_01Smezyj7ctQjTD9HbCjJ8G1