### PR TITLE
feat(ui): reduce font sizes, add per-round costs, and extend debate button

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -395,6 +395,38 @@ def add_unified_message(
     save_conversation(conversation, user_id)
 
 
+def update_last_arena_message(
+    conversation_id: str,
+    result: DeliberationResult,
+    user_id: str | None = None,
+) -> None:
+    """Update the last arena message with extended debate results.
+
+    This replaces the last assistant message (which should be an arena debate)
+    with updated rounds and synthesis.
+
+    Args:
+        conversation_id: Conversation identifier
+        result: Updated DeliberationResult with extended debate
+        user_id: Optional username for user-scoped storage
+    """
+    conversation = get_conversation(conversation_id, user_id, migrate_messages=False)
+    if conversation is None:
+        raise ValueError(f"Conversation {conversation_id} not found")
+
+    # Find and replace the last arena message
+    for i in range(len(conversation["messages"]) - 1, -1, -1):
+        msg = conversation["messages"][i]
+        if msg.get("role") == "assistant" and msg.get("mode") == "arena":
+            message = result.to_dict()
+            message["role"] = "assistant"
+            conversation["messages"][i] = message
+            save_conversation(conversation, user_id)
+            return
+
+    raise ValueError("No arena message found to update")
+
+
 # =============================================================================
 # Pending Message Tracking
 # =============================================================================

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,9 @@ function App() {
   // Fork conversation state - context to include when starting a new conversation
   const [pendingForkContext, setPendingForkContext] = useState(null);
 
+  // Extend debate state
+  const [isExtendingDebate, setIsExtendingDebate] = useState(false);
+
   // Load conversations, config, and user info on mount
   useEffect(() => {
     loadConversations();
@@ -307,6 +310,120 @@ function App() {
       });
     } catch (error) {
       console.error('Failed to fork conversation:', error);
+    }
+  };
+
+  const handleExtendDebate = async () => {
+    if (!currentConversationId || isExtendingDebate) return;
+
+    setIsExtendingDebate(true);
+    try {
+      await api.extendDebateStream(currentConversationId, (eventType, event) => {
+        switch (eventType) {
+          case 'extend_start':
+            // Starting to extend
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.loading = {
+                  ...lastMsg.loading,
+                  round: true,
+                  roundNumber: event.data.new_round_number,
+                  roundType: 'deliberation',
+                };
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'round_start':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.loading = {
+                  ...lastMsg.loading,
+                  round: true,
+                  roundNumber: event.data.round_number,
+                  roundType: event.data.round_type,
+                };
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'round_complete':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.rounds = [...(lastMsg.rounds || []), event.data];
+                lastMsg.loading = {
+                  ...lastMsg.loading,
+                  round: false,
+                  roundNumber: null,
+                  roundType: null,
+                };
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'synthesis_start':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.loading = {
+                  ...lastMsg.loading,
+                  synthesis: true,
+                };
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'synthesis_complete':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.synthesis = event.data;
+                lastMsg.participant_mapping = event.participant_mapping;
+                lastMsg.loading = {
+                  ...lastMsg.loading,
+                  synthesis: false,
+                };
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'metrics_complete':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (lastMsg.mode === 'arena') {
+                lastMsg.metrics = event.data;
+              }
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'complete':
+            setIsExtendingDebate(false);
+            break;
+
+          case 'error':
+            console.error('Extend debate error:', event.message);
+            setIsExtendingDebate(false);
+            break;
+        }
+      });
+    } catch (error) {
+      console.error('Failed to extend debate:', error);
+      setIsExtendingDebate(false);
     }
   };
 
@@ -610,7 +727,9 @@ function App() {
         onRetryInterrupted={handleRetryInterrupted}
         onDismissInterrupted={handleDismissInterrupted}
         onForkConversation={handleForkConversation}
+        onExtendDebate={handleExtendDebate}
         isLoading={isLoading}
+        isExtendingDebate={isExtendingDebate}
         webSearchAvailable={webSearchAvailable}
         searchProvider={searchProvider}
         useWebSearch={useWebSearch}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -366,4 +366,49 @@ export const api = {
       }
     }
   },
+
+  /**
+   * Extend an arena debate with one more deliberation round.
+   * @param {string} conversationId - The conversation ID
+   * @param {function} onEvent - Callback function for each event: (eventType, data) => void
+   * @returns {Promise<void>}
+   */
+  async extendDebateStream(conversationId, onEvent) {
+    const response = await fetch(
+      `${API_BASE}/api/conversations/${conversationId}/extend-debate/stream`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('Failed to extend debate');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value);
+      const lines = chunk.split('\n');
+
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          const data = line.slice(6);
+          try {
+            const event = JSON.parse(data);
+            onEvent(event.type, event);
+          } catch (e) {
+            console.error('Failed to parse SSE event:', e);
+          }
+        }
+      }
+    }
+  },
 };

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -27,7 +27,7 @@
 
 .empty-state h2 {
   font-family: var(--font-display);
-  font-size: 1.75rem;
+  font-size: 1.5rem;
   font-weight: 600;
   margin: 0 0 var(--space-md) 0;
   color: var(--color-text-primary);
@@ -35,7 +35,7 @@
 
 .empty-state p {
   margin: 0 0 var(--space-xl) 0;
-  font-size: 1.0625rem;
+  font-size: 0.9375rem;
   color: var(--color-text-secondary);
   max-width: 400px;
   line-height: 1.6;
@@ -73,7 +73,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   font-family: var(--font-body);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--color-text-secondary);
   cursor: pointer;
   transition: all var(--transition-fast);
@@ -226,7 +226,7 @@
   gap: var(--space-md);
   padding: var(--space-lg);
   color: var(--color-text-secondary);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
 }
 
 .stage-loading {
@@ -239,7 +239,7 @@
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   font-style: italic;
 }
 
@@ -280,7 +280,7 @@
   border-radius: var(--radius-md);
   color: var(--color-text-primary);
   font-family: var(--font-body);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.6;
   outline: none;
   resize: vertical;

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -94,7 +94,9 @@ export default function ChatInterface({
   onRetryInterrupted,
   onDismissInterrupted,
   onForkConversation,
+  onExtendDebate,
   isLoading,
+  isExtendingDebate,
   webSearchAvailable,
   searchProvider,
   useWebSearch,
@@ -547,6 +549,8 @@ export default function ChatInterface({
                             originalQuestion={conversation?.messages[index - 1]?.content}
                             conversationId={conversation?.id}
                             onForkConversation={onForkConversation}
+                            onExtendDebate={isArena ? onExtendDebate : undefined}
+                            isExtending={isExtendingDebate}
                             mode={mode}
                           />
                         )}

--- a/frontend/src/components/MetricsDisplay.css
+++ b/frontend/src/components/MetricsDisplay.css
@@ -57,7 +57,7 @@
 .metric-value {
   font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.8125rem;
   color: var(--color-text-primary);
 }
 
@@ -112,11 +112,11 @@
 
 .stage-row {
   display: grid;
-  grid-template-columns: 1fr 80px 100px 80px;
-  gap: var(--space-md);
+  grid-template-columns: 1fr 70px 90px 70px;
+  gap: var(--space-sm);
   align-items: center;
-  font-size: 0.8125rem;
-  padding: var(--space-sm) var(--space-md);
+  font-size: 0.75rem;
+  padding: var(--space-xs) var(--space-sm);
   background: var(--color-surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-light);
@@ -137,13 +137,13 @@
 .stage-tokens {
   font-family: var(--font-mono);
   color: var(--color-text-secondary);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .stage-latency {
   font-family: var(--font-mono);
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   text-align: right;
 }
 
@@ -165,10 +165,10 @@
 
 .model-row {
   display: grid;
-  grid-template-columns: 1fr 60px 60px 80px;
-  gap: var(--space-sm);
+  grid-template-columns: 1fr 55px 55px 70px;
+  gap: var(--space-xs);
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
   transition: background var(--transition-fast);

--- a/frontend/src/components/Round.css
+++ b/frontend/src/components/Round.css
@@ -59,9 +59,27 @@
 
 .round-title {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--text-primary, #333);
+}
+
+.round-cost {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-gold-dark, #9A7F42);
+  background: color-mix(in srgb, var(--color-gold, #C4A35A) 15%, transparent);
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: auto;
+}
+
+.round-cost svg {
+  opacity: 0.7;
 }
 
 .collapse-toggle {
@@ -77,7 +95,7 @@
 .round-description {
   padding: 0.75rem 1rem;
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary, #666);
   background: var(--surface-secondary, #f8f9fa);
   border-bottom: 1px solid var(--border-color, #e0e0e0);
@@ -97,11 +115,11 @@
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.625rem;
   border: 1px solid var(--border-color, #ddd);
   border-radius: 4px;
   background: var(--surface-color, #fff);
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   color: var(--text-primary, #333);
   cursor: pointer;
   transition: all 0.15s ease;
@@ -152,7 +170,7 @@
 }
 
 .model-name {
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary, #666);
 }
 
@@ -191,7 +209,7 @@
   background: color-mix(in srgb, var(--warning-color, #f59e0b) 10%, transparent);
   border: none;
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-primary, #333);
 }
 
@@ -202,7 +220,7 @@
 .reasoning-content {
   padding: 0.75rem;
   background: var(--surface-secondary, #f8f9fa);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary, #555);
   border-top: 1px solid var(--border-color, #e0e0e0);
 }
@@ -218,7 +236,7 @@
   padding: 0.75rem;
   background: var(--surface-secondary, #f8f9fa);
   border-radius: 6px;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .parsed-ranking ol {
@@ -239,13 +257,13 @@
 
 .aggregate-rankings h4 {
   margin: 0 0 0.5rem 0;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   color: var(--text-primary, #333);
 }
 
 .aggregate-rankings .description {
   margin: 0 0 0.75rem 0;
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   color: var(--text-secondary, #666);
 }
 
@@ -262,7 +280,7 @@
   padding: 0.5rem 0.75rem;
   background: var(--surface-secondary, #f8f9fa);
   border-radius: 6px;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .rank-position {

--- a/frontend/src/components/Round.jsx
+++ b/frontend/src/components/Round.jsx
@@ -1,8 +1,15 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { ChevronDown, ChevronRight, Brain, Copy, Check } from 'lucide-react';
+import { ChevronDown, ChevronRight, Brain, Copy, Check, DollarSign } from 'lucide-react';
 import MetricsDisplay from './MetricsDisplay';
 import './Round.css';
+
+// Format cost for display
+function formatCost(cost) {
+  if (!cost || cost === 0) return null;
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  return `$${cost.toFixed(2)}`;
+}
 
 // Round type labels for display
 const ROUND_TYPE_LABELS = {
@@ -68,6 +75,20 @@ export default function Round({
   const isArenaRound = ['opening', 'rebuttal', 'closing'].includes(roundType);
   const roundLabel = ROUND_TYPE_LABELS[roundType] || `Round ${round.round_number}`;
 
+  // Calculate round cost from metrics or responses
+  const getRoundCost = () => {
+    if (round.metrics?.cost) return round.metrics.cost;
+    if (round.metrics?.total_cost) return round.metrics.total_cost;
+    // Sum from individual responses
+    let total = 0;
+    for (const resp of round.responses) {
+      const cost = resp.metrics?.cost || 0;
+      total += cost;
+    }
+    return total;
+  };
+  const roundCost = getRoundCost();
+
   const currentResponse = round.responses[activeTab];
   const reasoningText = getReasoningText(currentResponse.reasoning_details);
   const hasReasoning = !!reasoningText;
@@ -110,6 +131,12 @@ export default function Round({
         <div className="round-title-row">
           {round.round_number && <span className="round-number">Round {round.round_number}</span>}
           <h3 className="round-title">{roundLabel}</h3>
+          {roundCost > 0 && (
+            <span className="round-cost" title="Cost for this round">
+              <DollarSign size={12} />
+              {formatCost(roundCost)}
+            </span>
+          )}
         </div>
         {isCollapsible && (
           <button className="collapse-toggle" aria-label={isCollapsed ? 'Expand' : 'Collapse'}>

--- a/frontend/src/components/Synthesis.css
+++ b/frontend/src/components/Synthesis.css
@@ -29,7 +29,7 @@
 .synthesis-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-text-primary);
   display: flex;
@@ -39,11 +39,34 @@
 
 .synthesis-title::before {
   content: '';
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   background: var(--color-gold);
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.synthesis-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.synthesis-cost {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-gold-dark);
+  background: var(--color-gold-light);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.synthesis-cost svg {
+  opacity: 0.7;
 }
 
 .synthesis .copy-btn {
@@ -137,7 +160,7 @@
   padding: var(--space-md);
   background: var(--color-surface);
   border-top: 1px solid var(--color-border);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--color-text-secondary);
   line-height: 1.65;
   max-height: 300px;
@@ -187,7 +210,7 @@
   align-items: center;
   gap: var(--space-sm);
   font-family: var(--font-mono);
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   padding: var(--space-xs) 0;
 }
 
@@ -212,7 +235,62 @@
   font-style: italic;
 }
 
-/* Continue Discussion */
+/* Action buttons section */
+.synthesis-actions {
+  padding: var(--space-md) var(--space-lg);
+  border-top: 1px dashed var(--color-border);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
+/* One more round button */
+.extend-debate-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-gold-light);
+  border: 1px solid var(--color-gold);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-gold-dark);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.extend-debate-btn:hover:not(:disabled) {
+  background: var(--color-gold);
+  color: white;
+}
+
+.extend-debate-btn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.extend-debate-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.spinner-small {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-gold-dark);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Continue Discussion - legacy */
 .continue-discussion {
   padding: var(--space-md) var(--space-lg);
   border-top: 1px dashed var(--color-border);
@@ -249,7 +327,7 @@
 /* Markdown content styling */
 .synthesis .markdown-content h2 {
   font-family: var(--font-display);
-  font-size: 1rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: var(--color-text-primary);
   margin-top: 1.5em;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -252,10 +252,10 @@ body::before {
   margin-top: 0;
 }
 
-.markdown-content h1 { font-size: 1.75rem; }
-.markdown-content h2 { font-size: 1.5rem; }
-.markdown-content h3 { font-size: 1.25rem; }
-.markdown-content h4 { font-size: 1.125rem; }
+.markdown-content h1 { font-size: 1.5rem; }
+.markdown-content h2 { font-size: 1.25rem; }
+.markdown-content h3 { font-size: 1.0625rem; }
+.markdown-content h4 { font-size: 1rem; }
 
 .markdown-content ul,
 .markdown-content ol {


### PR DESCRIPTION
- Tone down font sizes across all CSS files for a more compact display
- Add cost display per round/phase in Round and Synthesis headers
- Add "One More Round" button for arena mode debates to extend discussions
- Backend: Add /api/conversations/{id}/extend-debate/stream endpoint
- Storage: Add update_last_arena_message function for extending debates

https://claude.ai/code/session_014J6YmuNiLSuQ5CsCYWNpYW