### PR TITLE
refactor: extract useConversationStream hook with useReducer and AbortController

### DIFF
--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -343,6 +343,26 @@
   cursor: not-allowed;
 }
 
+.cancel-button {
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-parchment);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.cancel-button:hover {
+  background: var(--color-burgundy-light);
+  color: #fff;
+  border-color: var(--color-burgundy);
+}
+
 /* Web Search Toggle */
 .web-search-toggle {
   display: flex;

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -95,6 +95,7 @@ export default function ChatInterface({
   onDismissInterrupted,
   onForkConversation,
   onExtendDebate,
+  onCancel,
   isLoading,
   isExtendingDebate,
   webSearchAvailable,
@@ -216,10 +217,14 @@ export default function ChatInterface({
       handleSubmit(e);
     }
 
-    // Escape to clear input
+    // Escape to cancel stream or clear input
     if (e.key === 'Escape') {
-      setInput('');
-      e.target.blur();
+      if (isLoading || isExtendingDebate) {
+        onCancel?.();
+      } else {
+        setInput('');
+        e.target.blur();
+      }
     }
   };
 
@@ -741,9 +746,20 @@ export default function ChatInterface({
               </span>
             </label>
           )}
-          <button type="submit" className="send-button" disabled={!input.trim() || isLoading}>
-            {mode === 'arena' ? 'Start Debate' : 'Send'}
-          </button>
+          {(isLoading || isExtendingDebate) ? (
+            <button
+              type="button"
+              className="cancel-button"
+              onClick={onCancel}
+              title="Cancel stream (Esc)"
+            >
+              Cancel
+            </button>
+          ) : (
+            <button type="submit" className="send-button" disabled={!input.trim()}>
+              {mode === 'arena' ? 'Start Debate' : 'Send'}
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/frontend/src/hooks/conversationReducer.js
+++ b/frontend/src/hooks/conversationReducer.js
@@ -1,0 +1,285 @@
+/**
+ * Pure reducer for conversation state.
+ *
+ * Every action maps an SSE event (or internal action) to an immutable
+ * state update on `currentConversation`. No side-effects live here —
+ * callbacks like loadConversations() are handled by the hook layer.
+ */
+
+// --- Helpers -----------------------------------------------------------------
+
+/** Clone messages array and the last message for immutable update. */
+function cloneLastMessage(state) {
+  const messages = [...state.messages];
+  const lastMsg = { ...messages[messages.length - 1] };
+  messages[messages.length - 1] = lastMsg;
+  return { messages, lastMsg };
+}
+
+// --- Exported helpers --------------------------------------------------------
+
+/** Build the initial skeleton assistant message for a given mode. */
+export function buildAssistantMessage(mode) {
+  if (mode === 'arena') {
+    return {
+      role: 'assistant',
+      mode: 'arena',
+      rounds: [],
+      synthesis: null,
+      participant_mapping: null,
+      webSearchUsed: false,
+      loading: {
+        webSearch: false,
+        round: false,
+        roundNumber: null,
+        roundType: null,
+        synthesis: false,
+      },
+    };
+  }
+
+  return {
+    role: 'assistant',
+    stage1: null,
+    stage2: null,
+    stage3: null,
+    metadata: null,
+    webSearchUsed: false,
+    loading: {
+      webSearch: false,
+      stage1: false,
+      stage2: false,
+      stage3: false,
+    },
+    streaming: {
+      models: [],
+      responses: [],
+      tokens: {},
+      progress: null,
+    },
+  };
+}
+
+// --- Reducer -----------------------------------------------------------------
+
+export function conversationReducer(state, action) {
+  // Guard: most actions require existing state
+  if (!state && action.type !== 'SET_CONVERSATION') return state;
+
+  switch (action.type) {
+    // ── Internal actions ─────────────────────────────────────────────────
+
+    case 'SET_CONVERSATION':
+      return action.payload;
+
+    case 'ADD_USER_MESSAGE': {
+      const { content, attachments } = action.payload;
+      const userMsg = { role: 'user', content };
+      if (attachments?.length > 0) userMsg.attachments = attachments;
+      return { ...state, messages: [...state.messages, userMsg] };
+    }
+
+    case 'ADD_ASSISTANT_MESSAGE': {
+      const msg = buildAssistantMessage(action.payload.mode);
+      return { ...state, messages: [...state.messages, msg] };
+    }
+
+    case 'ROLLBACK_OPTIMISTIC':
+      return { ...state, messages: state.messages.slice(0, -2) };
+
+    case 'UPDATE_TITLE':
+      return { ...state, title: action.payload.title };
+
+    case 'SET_LOADING':
+      return { ...state, _isLoading: action.payload.isLoading };
+
+    case 'SET_EXTENDING':
+      return { ...state, _isExtendingDebate: action.payload.isExtendingDebate };
+
+    // ── SSE: Shared events ───────────────────────────────────────────────
+
+    case 'web_search_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, webSearch: true };
+      return { ...state, messages };
+    }
+
+    case 'web_search_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, webSearch: false };
+      lastMsg.webSearchUsed = action.payload.data?.found || false;
+      lastMsg.webSearchError = action.payload.data?.error || null;
+      return { ...state, messages };
+    }
+
+    // ── SSE: Council Stage 1 ─────────────────────────────────────────────
+
+    case 'stage1_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, stage1: true };
+      if (action.payload.data?.models) {
+        lastMsg.streaming = {
+          models: action.payload.data.models,
+          responses: [],
+          tokens: {},
+          progress: {
+            completed: 0,
+            total: action.payload.data.models.length,
+            completed_models: [],
+            pending_models: action.payload.data.models,
+          },
+        };
+      }
+      return { ...state, messages };
+    }
+
+    case 'stage1_token': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      const { model, token } = action.payload.data;
+      lastMsg.streaming = {
+        ...lastMsg.streaming,
+        tokens: {
+          ...lastMsg.streaming.tokens,
+          [model]: (lastMsg.streaming.tokens[model] || '') + token,
+        },
+      };
+      return { ...state, messages };
+    }
+
+    case 'stage1_model_response': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      const newTokens = { ...lastMsg.streaming.tokens };
+      delete newTokens[action.payload.data.model];
+      lastMsg.streaming = {
+        ...lastMsg.streaming,
+        responses: [...lastMsg.streaming.responses, action.payload.data],
+        tokens: newTokens,
+      };
+      return { ...state, messages };
+    }
+
+    case 'stage1_progress': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.streaming = { ...lastMsg.streaming, progress: action.payload.data };
+      return { ...state, messages };
+    }
+
+    case 'stage1_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.stage1 = action.payload.data;
+      lastMsg.loading = { ...lastMsg.loading, stage1: false };
+      return { ...state, messages };
+    }
+
+    // ── SSE: Council Stage 2 ─────────────────────────────────────────────
+
+    case 'stage2_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, stage2: true };
+      return { ...state, messages };
+    }
+
+    case 'stage2_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.stage2 = action.payload.data;
+      lastMsg.metadata = action.payload.metadata;
+      lastMsg.loading = { ...lastMsg.loading, stage2: false };
+      return { ...state, messages };
+    }
+
+    // ── SSE: Council Stage 3 ─────────────────────────────────────────────
+
+    case 'stage3_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, stage3: true };
+      return { ...state, messages };
+    }
+
+    case 'stage3_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.stage3 = action.payload.data;
+      lastMsg.loading = { ...lastMsg.loading, stage3: false };
+      return { ...state, messages };
+    }
+
+    // ── SSE: Arena events ────────────────────────────────────────────────
+
+    case 'arena_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.arenaInfo = action.payload.data;
+      return { ...state, messages };
+    }
+
+    case 'round_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = {
+        ...lastMsg.loading,
+        round: true,
+        roundNumber: action.payload.data.round_number,
+        roundType: action.payload.data.round_type,
+      };
+      return { ...state, messages };
+    }
+
+    case 'round_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.rounds = [...(lastMsg.rounds || []), action.payload.data];
+      lastMsg.loading = {
+        ...lastMsg.loading,
+        round: false,
+        roundNumber: null,
+        roundType: null,
+      };
+      return { ...state, messages };
+    }
+
+    case 'synthesis_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.loading = { ...lastMsg.loading, synthesis: true };
+      return { ...state, messages };
+    }
+
+    case 'synthesis_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.synthesis = action.payload.data;
+      lastMsg.participant_mapping = action.payload.participant_mapping;
+      lastMsg.loading = { ...lastMsg.loading, synthesis: false };
+      return { ...state, messages };
+    }
+
+    // ── SSE: Extend debate ───────────────────────────────────────────────
+
+    case 'extend_start': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      if (lastMsg.mode === 'arena') {
+        lastMsg.loading = {
+          ...lastMsg.loading,
+          round: true,
+          roundNumber: action.payload.data.new_round_number,
+          roundType: 'deliberation',
+        };
+      }
+      return { ...state, messages };
+    }
+
+    // ── SSE: Shared completion ───────────────────────────────────────────
+
+    case 'metrics_complete': {
+      const { messages, lastMsg } = cloneLastMessage(state);
+      lastMsg.metrics = action.payload.data;
+      return { ...state, messages };
+    }
+
+    // Side-effect-only events — state unchanged, hook handles callbacks
+    case 'resume_start':
+    case 'prior_context':
+    case 'title_complete':
+    case 'complete':
+    case 'error':
+      return state;
+
+    default:
+      console.log('Unknown event:', action.type);
+      return state;
+  }
+}

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -10,3 +10,4 @@ export {
   useAutoExpandableGroups,
 } from './useExpandableGroups';
 export { useTheme } from './useTheme';
+export { useConversationStream } from './useConversationStream';

--- a/frontend/src/hooks/useConversationStream.js
+++ b/frontend/src/hooks/useConversationStream.js
@@ -1,0 +1,142 @@
+/**
+ * Custom hook that owns conversation state (via useReducer),
+ * an AbortController for cancellation, and the streaming API calls.
+ *
+ * Side effects (e.g. refreshing the sidebar) are delegated to
+ * callbacks passed in via the options object.
+ */
+import { useCallback, useReducer, useRef } from 'react';
+import { api } from '../api';
+import { conversationReducer, buildAssistantMessage } from './conversationReducer';
+
+/**
+ * @param {Object} options
+ * @param {() => void} [options.onComplete]      Called when a stream finishes successfully.
+ * @param {() => void} [options.onTitleComplete]  Called when backend generates a title.
+ */
+export function useConversationStream({ onComplete, onTitleComplete } = {}) {
+  const [conversation, dispatch] = useReducer(conversationReducer, null);
+  const abortRef = useRef(null);
+
+  // ── Derived state ──────────────────────────────────────────────────────
+  const isLoading = conversation?._isLoading ?? false;
+  const isExtendingDebate = conversation?._isExtendingDebate ?? false;
+
+  // ── Low-level setters ──────────────────────────────────────────────────
+
+  const setConversation = useCallback((conv) => {
+    dispatch({ type: 'SET_CONVERSATION', payload: conv });
+  }, []);
+
+  const updateTitle = useCallback((title) => {
+    dispatch({ type: 'UPDATE_TITLE', payload: { title } });
+  }, []);
+
+  // ── Cancel ─────────────────────────────────────────────────────────────
+
+  const cancelStream = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    dispatch({ type: 'SET_LOADING', payload: { isLoading: false } });
+    dispatch({ type: 'SET_EXTENDING', payload: { isExtendingDebate: false } });
+  }, []);
+
+  // ── Send message ───────────────────────────────────────────────────────
+
+  const sendMessage = useCallback(async (
+    conversationId,
+    content,
+    attachments,
+    { mode, useWebSearch, arenaRoundCount, resume, priorContext }
+  ) => {
+    // Cancel any in-flight stream
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    dispatch({ type: 'SET_LOADING', payload: { isLoading: true } });
+    dispatch({ type: 'ADD_USER_MESSAGE', payload: { content, attachments } });
+    dispatch({ type: 'ADD_ASSISTANT_MESSAGE', payload: { mode } });
+
+    const arenaConfig = mode === 'arena' ? { round_count: arenaRoundCount } : null;
+
+    try {
+      await api.sendMessageStream(
+        conversationId,
+        content,
+        useWebSearch,
+        mode,
+        arenaConfig,
+        attachments,
+        (eventType, event) => {
+          if (controller.signal.aborted) return;
+          dispatch({ type: eventType, payload: event });
+
+          if (eventType === 'title_complete') onTitleComplete?.();
+          if (eventType === 'complete') {
+            dispatch({ type: 'SET_LOADING', payload: { isLoading: false } });
+            onComplete?.();
+          }
+          if (eventType === 'error') {
+            dispatch({ type: 'SET_LOADING', payload: { isLoading: false } });
+          }
+        },
+        resume,
+        priorContext,
+        controller.signal,
+      );
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      console.error('Failed to send message:', error);
+      dispatch({ type: 'ROLLBACK_OPTIMISTIC' });
+      dispatch({ type: 'SET_LOADING', payload: { isLoading: false } });
+    }
+  }, [onComplete, onTitleComplete]);
+
+  // ── Extend debate ──────────────────────────────────────────────────────
+
+  const extendDebate = useCallback(async (conversationId) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    dispatch({ type: 'SET_EXTENDING', payload: { isExtendingDebate: true } });
+
+    try {
+      await api.extendDebateStream(
+        conversationId,
+        (eventType, event) => {
+          if (controller.signal.aborted) return;
+          dispatch({ type: eventType, payload: event });
+
+          if (eventType === 'complete') {
+            dispatch({ type: 'SET_EXTENDING', payload: { isExtendingDebate: false } });
+            onComplete?.();
+          }
+          if (eventType === 'error') {
+            dispatch({ type: 'SET_EXTENDING', payload: { isExtendingDebate: false } });
+          }
+        },
+        controller.signal,
+      );
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      console.error('Failed to extend debate:', error);
+      dispatch({ type: 'SET_EXTENDING', payload: { isExtendingDebate: false } });
+    }
+  }, [onComplete]);
+
+  // ── Public API ─────────────────────────────────────────────────────────
+
+  return {
+    conversation,
+    isLoading,
+    isExtendingDebate,
+    setConversation,
+    sendMessage,
+    extendDebate,
+    cancelStream,
+    updateTitle,
+    dispatch, // escape hatch for edge cases
+  };
+}


### PR DESCRIPTION
## Summary

- Extract `conversationReducer` — pure event-to-state mapping for 23 SSE event types + internal actions
- Add `useConversationStream` hook wrapping reducer + AbortController + streaming API calls
- Wire into App.jsx, deleting 298-line `handleSendMessage` and 112-line `handleExtendDebate` (net -391 lines)
- Add AbortController `signal` support to `sendMessageStream` and `extendDebateStream` in api.js
- Add Cancel button + Escape key to stop active streams in ChatInterface

## Test Plan

- [ ] Council mode: send question, verify 3-stage streaming renders
- [ ] Arena mode: start debate, verify rounds and synthesis render
- [ ] Extend debate: new round appends correctly
- [ ] Cancel button: visible during streaming, stops stream cleanly
- [ ] Escape key: cancels active stream
- [ ] State clean after cancel: can send new message
- [ ] Error recovery: stop backend mid-stream, optimistic messages rolled back
- [ ] Resume: interrupted conversations resume correctly
- [ ] Rename conversation: title updates in sidebar
- [ ] Web search toggle: search badge appears

Closes council-rsq

🤖 Generated with [Claude Code](https://claude.com/claude-code)