### PR TITLE
fix(council): support 26+ models in stage2 labels

### DIFF
--- a/backend/council.py
+++ b/backend/council.py
@@ -27,6 +27,81 @@ from .websearch import format_search_results, is_web_search_available, search_we
 
 logger = logging.getLogger(__name__)
 
+STAGE2_SYSTEM_PROMPT = (
+    "You are an impartial evaluator. Assess each response on its own merits. "
+    "Be rigorous, specific, and honest in your evaluation."
+)
+
+
+def generate_response_labels(count: int) -> list[str]:
+    """Generate sequential response labels: A-Z, then AA, AB, ..., AZ, BA, etc.
+
+    Args:
+        count: Number of labels to generate
+
+    Returns:
+        List of label strings (e.g., ['A', 'B', ..., 'Z', 'AA', 'AB', ...])
+    """
+    labels: list[str] = []
+    for i in range(count):
+        if i < 26:
+            labels.append(chr(65 + i))
+        else:
+            first = chr(65 + (i - 26) // 26)
+            second = chr(65 + (i - 26) % 26)
+            labels.append(first + second)
+    return labels
+
+
+def _build_ranking_prompt(user_query: str, responses_text: str) -> str:
+    """Build the Stage 2 ranking prompt.
+
+    Args:
+        user_query: The original user question
+        responses_text: Pre-formatted anonymized responses text
+
+    Returns:
+        The complete ranking prompt string
+    """
+    return f"""You are a rigorous evaluator assessing responses to the following question:
+
+Question: {user_query}
+
+Here are the responses from different models (anonymized):
+
+{responses_text}
+
+EVALUATION CRITERIA - Be ruthlessly honest:
+- Accuracy: Are there factual errors, unsupported claims, or logical fallacies?
+- Completeness: Does it actually answer the question, or dodge/deflect?
+- Depth: Is the reasoning superficial or substantive?
+- Honesty: Does it acknowledge uncertainty, or pretend to know what it doesn't?
+- Usefulness: Would this actually help someone, or is it generic filler?
+
+Your task:
+1. Critically evaluate each response. Call out specific flaws, errors, and weaknesses. Don't be kind - be accurate.
+2. Note what each response does well, if anything.
+3. Provide a final ranking based on actual quality, not politeness.
+
+IMPORTANT: Your final ranking MUST be formatted EXACTLY as follows:
+- Start with the line "FINAL RANKING:" (all caps, with colon)
+- Then list the responses from best to worst as a numbered list
+- Each line should be: number, period, space, then ONLY the response label (e.g., "1. Response A")
+- Do not add any other text or explanations in the ranking section
+
+Example format:
+
+Response A contains a factual error about X and fails to address Y...
+Response B provides accurate information but is too vague on Z...
+Response C is the most thorough but overstates confidence in its claims...
+
+FINAL RANKING:
+1. Response C
+2. Response B
+3. Response A
+
+Now provide your critical evaluation and ranking:"""
+
 
 async def stage1_collect_responses(
     user_query: str,
@@ -235,7 +310,7 @@ async def stage2_collect_rankings(
         Tuple of (rankings list, label_to_model mapping)
     """
     tracer = get_tracer()
-    effective_council = council_models if council_models else get_council_models()
+    effective_council = council_models if council_models is not None else get_council_models()
 
     span_attributes = {
         "council.stage": 2,
@@ -245,8 +320,8 @@ async def stage2_collect_rankings(
     }
 
     with tracer.start_as_current_span("council.stage2_collect_rankings", attributes=span_attributes) as span:
-        # Create anonymized labels for responses (Response A, Response B, etc.)
-        labels = [chr(65 + i) for i in range(len(stage1_results))]  # A, B, C, ...
+        # Create anonymized labels for responses (A, B, C, ..., Z, AA, AB, ...)
+        labels = generate_response_labels(len(stage1_results))
 
         # Create mapping from label to model name
         label_to_model = {
@@ -260,52 +335,19 @@ async def stage2_collect_rankings(
             for label, result in zip(labels, stage1_results)
         ])
 
-        ranking_prompt = f"""You are a rigorous evaluator assessing responses to the following question:
+        ranking_prompt = _build_ranking_prompt(user_query, responses_text)
 
-Question: {user_query}
-
-Here are the responses from different models (anonymized):
-
-{responses_text}
-
-EVALUATION CRITERIA - Be ruthlessly honest:
-- Accuracy: Are there factual errors, unsupported claims, or logical fallacies?
-- Completeness: Does it actually answer the question, or dodge/deflect?
-- Depth: Is the reasoning superficial or substantive?
-- Honesty: Does it acknowledge uncertainty, or pretend to know what it doesn't?
-- Usefulness: Would this actually help someone, or is it generic filler?
-
-Your task:
-1. Critically evaluate each response. Call out specific flaws, errors, and weaknesses. Don't be kind - be accurate.
-2. Note what each response does well, if anything.
-3. Provide a final ranking based on actual quality, not politeness.
-
-IMPORTANT: Your final ranking MUST be formatted EXACTLY as follows:
-- Start with the line "FINAL RANKING:" (all caps, with colon)
-- Then list the responses from best to worst as a numbered list
-- Each line should be: number, period, space, then ONLY the response label (e.g., "1. Response A")
-- Do not add any other text or explanations in the ranking section
-
-Example format:
-
-Response A contains a factual error about X and fails to address Y...
-Response B provides accurate information but is too vague on Z...
-Response C is the most thorough but overstates confidence in its claims...
-
-FINAL RANKING:
-1. Response C
-2. Response B
-3. Response A
-
-Now provide your critical evaluation and ranking:"""
-
-        messages = [{"role": "user", "content": ranking_prompt}]
+        messages = [
+            {"role": "system", "content": STAGE2_SYSTEM_PROMPT},
+            {"role": "user", "content": ranking_prompt},
+        ]
 
         # Get rankings from all council models in parallel
         responses = await query_models_parallel(effective_council, messages)
 
         # Format results
         stage2_results = []
+        failed_models = []
         for model, response in responses.items():
             if response is not None:
                 full_text = response.get('content', '')
@@ -320,6 +362,13 @@ Now provide your critical evaluation and ranking:"""
                 if response.get('reasoning_details'):
                     result['reasoning_details'] = response['reasoning_details']
                 stage2_results.append(result)
+            else:
+                failed_models.append(model)
+
+        if failed_models:
+            logger.warning(
+                "Stage 2 ranking failed for models: %s", ", ".join(failed_models)
+            )
 
         # Record ranking count in span
         if is_telemetry_enabled():
@@ -443,19 +492,19 @@ def parse_ranking_from_text(ranking_text: str) -> list[str]:
         parts = ranking_text.split("FINAL RANKING:")
         if len(parts) >= 2:
             ranking_section = parts[1]
-            # Try to extract numbered list format (e.g., "1. Response A")
-            # This pattern looks for: number, period, optional space, "Response X"
-            numbered_matches = re.findall(r'\d+\.\s*Response [A-Z]', ranking_section)
+            # Try to extract numbered list format (e.g., "1. Response A" or "1. Response AA")
+            # This pattern looks for: number, period, optional space, "Response X[X]"
+            numbered_matches = re.findall(r'\d+\.\s*Response [A-Z]+', ranking_section)
             if numbered_matches:
                 # Extract just the "Response X" part
-                return [re.search(r'Response [A-Z]', m).group() for m in numbered_matches]
+                return [re.search(r'Response [A-Z]+', m).group() for m in numbered_matches]
 
             # Fallback: Extract all "Response X" patterns in order
-            matches = re.findall(r'Response [A-Z]', ranking_section)
+            matches = re.findall(r'Response [A-Z]+', ranking_section)
             return matches
 
     # Fallback: try to find any "Response X" patterns in order
-    matches = re.findall(r'Response [A-Z]', ranking_text)
+    matches = re.findall(r'Response [A-Z]+', ranking_text)
     return matches
 
 

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -1,12 +1,117 @@
 """Tests for pure functions in backend.council."""
 
 from backend.council import (
+    STAGE2_SYSTEM_PROMPT,
+    _build_ranking_prompt,
     aggregate_metrics,
     calculate_aggregate_rankings,
     convert_legacy_message_to_unified,
     convert_to_unified_result,
+    generate_response_labels,
     parse_ranking_from_text,
 )
+
+
+# ---------------------------------------------------------------------------
+# generate_response_labels
+# ---------------------------------------------------------------------------
+
+class TestGenerateResponseLabels:
+    """Tests for generate_response_labels."""
+
+    def test_zero_labels(self):
+        """Zero count returns empty list."""
+        assert generate_response_labels(0) == []
+
+    def test_single_label(self):
+        """Single label is A."""
+        assert generate_response_labels(1) == ["A"]
+
+    def test_first_26_are_single_letters(self):
+        """First 26 labels are A through Z."""
+        labels = generate_response_labels(26)
+        assert labels[0] == "A"
+        assert labels[25] == "Z"
+        assert len(labels) == 26
+
+    def test_27th_label_is_aa(self):
+        """27th label (index 26) is AA, not a non-letter character."""
+        labels = generate_response_labels(27)
+        assert labels[26] == "AA"
+
+    def test_28th_label_is_ab(self):
+        """28th label is AB."""
+        labels = generate_response_labels(28)
+        assert labels[27] == "AB"
+
+    def test_52nd_label_is_az(self):
+        """52nd label (index 51) is AZ."""
+        labels = generate_response_labels(52)
+        assert labels[51] == "AZ"
+
+    def test_53rd_label_is_ba(self):
+        """53rd label (index 52) is BA."""
+        labels = generate_response_labels(53)
+        assert labels[52] == "BA"
+
+    def test_all_labels_unique(self):
+        """100 labels are all unique."""
+        labels = generate_response_labels(100)
+        assert len(labels) == len(set(labels))
+
+    def test_all_labels_are_uppercase_alpha(self):
+        """All generated labels contain only uppercase letters."""
+        labels = generate_response_labels(100)
+        for label in labels:
+            assert label.isalpha() and label.isupper(), f"Bad label: {label!r}"
+
+
+# ---------------------------------------------------------------------------
+# _build_ranking_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildRankingPrompt:
+    """Tests for _build_ranking_prompt."""
+
+    def test_contains_user_query(self):
+        """Prompt includes the user query."""
+        prompt = _build_ranking_prompt("What is Python?", "Response A:\nAnswer")
+        assert "What is Python?" in prompt
+
+    def test_contains_responses_text(self):
+        """Prompt includes the responses text."""
+        prompt = _build_ranking_prompt("Q?", "Response A:\nFoo\n\nResponse B:\nBar")
+        assert "Response A:\nFoo" in prompt
+        assert "Response B:\nBar" in prompt
+
+    def test_contains_final_ranking_instructions(self):
+        """Prompt includes FINAL RANKING format instructions."""
+        prompt = _build_ranking_prompt("Q?", "Response A:\nTest")
+        assert "FINAL RANKING:" in prompt
+        assert "1. Response A" in prompt
+
+    def test_contains_evaluation_criteria(self):
+        """Prompt includes evaluation criteria."""
+        prompt = _build_ranking_prompt("Q?", "Response A:\nTest")
+        assert "Accuracy" in prompt
+        assert "Completeness" in prompt
+
+
+# ---------------------------------------------------------------------------
+# STAGE2_SYSTEM_PROMPT
+# ---------------------------------------------------------------------------
+
+class TestStage2SystemPrompt:
+    """Tests for STAGE2_SYSTEM_PROMPT constant."""
+
+    def test_is_nonempty_string(self):
+        """System prompt is a non-empty string."""
+        assert isinstance(STAGE2_SYSTEM_PROMPT, str)
+        assert len(STAGE2_SYSTEM_PROMPT) > 0
+
+    def test_mentions_evaluator_role(self):
+        """System prompt establishes the evaluator role."""
+        assert "evaluator" in STAGE2_SYSTEM_PROMPT.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +213,29 @@ class TestParseRankingFromText:
             "2.Response B\n"
         )
         assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+    def test_multi_letter_labels_in_numbered_list(self):
+        """Multi-letter labels (AA, AB) parse correctly in numbered format."""
+        text = (
+            "FINAL RANKING:\n"
+            "1. Response AA\n"
+            "2. Response AB\n"
+            "3. Response Z\n"
+        )
+        assert parse_ranking_from_text(text) == [
+            "Response AA",
+            "Response AB",
+            "Response Z",
+        ]
+
+    def test_multi_letter_labels_fallback(self):
+        """Multi-letter labels parse via fallback (no FINAL RANKING header)."""
+        text = "Best is Response AA, then Response BA, then Response A."
+        assert parse_ranking_from_text(text) == [
+            "Response AA",
+            "Response BA",
+            "Response A",
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `generate_response_labels()` for A-Z, then AA, AB, AC... pattern (handles 700+ models)
- Extract `_build_ranking_prompt()` helper and `STAGE2_SYSTEM_PROMPT` constant
- Fix falsy check (`council_models is not None`) so empty list raises properly
- Update `parse_ranking_from_text` regex to handle multi-letter labels (`[A-Z]+`)
- Add system message to stage2 ranking calls for better output quality
- Add logging for failed models in stage2

## Test plan
- [x] 17 new tests for `generate_response_labels`, `_build_ranking_prompt`, `STAGE2_SYSTEM_PROMPT`, and multi-letter label parsing
- [x] All 103 backend tests pass

Closes council-a0z

🤖 Generated with [Claude Code](https://claude.com/claude-code)