### PR TITLE
refactor(frontend): extract Sidebar utilities to sidebarUtils.js

### DIFF
--- a/frontend/src/__tests__/sidebarUtils.test.js
+++ b/frontend/src/__tests__/sidebarUtils.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getUserInitial, getUserDisplayName, getThemeLabel } from '../lib/sidebarUtils';
+
+// ---------------------------------------------------------------------------
+// getUserInitial
+// ---------------------------------------------------------------------------
+
+describe('getUserInitial', () => {
+  it('returns first letter of display_name uppercased', () => {
+    expect(getUserInitial({ display_name: 'cameron', username: 'cam' })).toBe('C');
+  });
+
+  it('falls back to username when no display_name', () => {
+    expect(getUserInitial({ username: 'alice' })).toBe('A');
+  });
+
+  it('returns ? when no name fields', () => {
+    expect(getUserInitial({})).toBe('?');
+  });
+
+  it('returns ? for null userInfo', () => {
+    expect(getUserInitial(null)).toBe('?');
+  });
+
+  it('handles uppercase names', () => {
+    expect(getUserInitial({ display_name: 'ADMIN' })).toBe('A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUserDisplayName
+// ---------------------------------------------------------------------------
+
+describe('getUserDisplayName', () => {
+  it('returns display_name when available', () => {
+    expect(getUserDisplayName({ display_name: 'Cameron Sjo', username: 'cam' })).toBe('Cameron Sjo');
+  });
+
+  it('falls back to username', () => {
+    expect(getUserDisplayName({ username: 'cam' })).toBe('cam');
+  });
+
+  it('returns empty string for null', () => {
+    expect(getUserDisplayName(null)).toBe('');
+  });
+
+  it('returns empty string for empty object', () => {
+    expect(getUserDisplayName({})).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getThemeLabel
+// ---------------------------------------------------------------------------
+
+describe('getThemeLabel', () => {
+  it('returns System for system theme', () => {
+    expect(getThemeLabel('system')).toBe('System');
+  });
+
+  it('returns Light for light theme', () => {
+    expect(getThemeLabel('light')).toBe('Light');
+  });
+
+  it('returns Dark for dark theme', () => {
+    expect(getThemeLabel('dark')).toBe('Dark');
+  });
+
+  it('returns System for unknown theme', () => {
+    expect(getThemeLabel('unknown')).toBe('System');
+  });
+});

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -6,6 +6,7 @@ import ModelSelector from './ModelSelector';
 import ModelCuration from './ModelCuration';
 import VersionInfo from './VersionInfo';
 import { useTheme } from '../hooks';
+import { getUserInitial, getUserDisplayName, getThemeLabel } from '../lib/sidebarUtils';
 
 export default function Sidebar({
   conversations,
@@ -69,11 +70,7 @@ export default function Sidebar({
     dark: <Moon size={16} />,
   }[theme];
 
-  const themeLabel = {
-    system: 'System',
-    light: 'Light',
-    dark: 'Dark',
-  }[theme];
+  const themeLabel = getThemeLabel(theme);
 
   const handleOpenConfig = () => {
     setPendingCouncil(councilModels);
@@ -110,10 +107,10 @@ export default function Sidebar({
         {userInfo?.authenticated && (
           <div className="user-info">
             <span className="user-avatar">
-              {(userInfo.display_name || userInfo.username || '?')[0].toUpperCase()}
+              {getUserInitial(userInfo)}
             </span>
             <span className="user-name">
-              {userInfo.display_name || userInfo.username}
+              {getUserDisplayName(userInfo)}
             </span>
           </div>
         )}

--- a/frontend/src/lib/sidebarUtils.js
+++ b/frontend/src/lib/sidebarUtils.js
@@ -1,0 +1,33 @@
+/**
+ * Pure utility functions for Sidebar component logic.
+ * Extracted from Sidebar.jsx for testability.
+ */
+
+/**
+ * Get the display initial for a user avatar.
+ * @param {Object|null} userInfo - User info object
+ * @returns {string} Single uppercase character for the avatar
+ */
+export function getUserInitial(userInfo) {
+  const name = userInfo?.display_name || userInfo?.username || '?';
+  return name[0].toUpperCase();
+}
+
+/**
+ * Get the display name for a user.
+ * @param {Object|null} userInfo - User info object
+ * @returns {string} Display name or username
+ */
+export function getUserDisplayName(userInfo) {
+  return userInfo?.display_name || userInfo?.username || '';
+}
+
+/**
+ * Get the label text for the current theme.
+ * @param {string} theme - Current theme ('system', 'light', 'dark')
+ * @returns {string} Human-readable theme label
+ */
+export function getThemeLabel(theme) {
+  const labels = { system: 'System', light: 'Light', dark: 'Dark' };
+  return labels[theme] || 'System';
+}


### PR DESCRIPTION
## Summary
- Extract `getUserInitial`, `getUserDisplayName`, `getThemeLabel` to `lib/sidebarUtils.js`
- Replace inline expressions in `Sidebar.jsx` with utility calls
- 13 new vitest tests

## Test plan
- [x] 13 new tests for all extracted functions
- [x] All 77 frontend tests pass

Closes council-9hu

🤖 Generated with [Claude Code](https://claude.com/claude-code)