### PR TITLE
chore: plugin scaffold + beads gitignore fix + beadspace doc

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,12 +1,15 @@
 # Dolt database (managed by Dolt, not git)
 dolt/
 dolt-access.lock
+embeddeddolt/
+backup/
 
 # Runtime files
 bd.sock
 bd.sock.startlock
 sync-state.json
 last-touched
+daemon-error
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "llm-council",
+  "owner": {
+    "name": "Cameron Sjo",
+    "github": "cameronsjo"
+  },
+  "plugins": [
+    {
+      "name": "llm-council",
+      "source": "./.claude-plugin",
+      "description": "Multi-LLM deliberation web app with Council and Arena debate modes"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "llm-council",
   "owner": {
     "name": "Cameron Sjo",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "llm-council",
+  "description": "Multi-LLM deliberation web app with Council and Arena debate modes",
+  "author": {
+    "name": "cameronsjo"
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "mcp__plugin_playwright_playwright__browser_take_screenshot",
       "Skill(frontend-design:frontend-design)",
       "mcp__plugin_playwright_playwright__browser_click",
-      "mcp__plugin_playwright_playwright__browser_snapshot"
+      "mcp__plugin_playwright_playwright__browser_snapshot",
+      "Bash(do echo \"=== $id ===\")"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ frontend/.vite/
 
 # Git worktrees
 .worktrees/
+
+# Review loop state (local, per-machine)
+*.local.md

--- a/docs/beadspace/community-submission.md
+++ b/docs/beadspace/community-submission.md
@@ -1,0 +1,46 @@
+# Beadspace — Community Tools Submission
+
+## COMMUNITY_TOOLS.md Entry
+
+For the **Web UIs** section:
+
+```markdown
+- **[Beadspace](https://github.com/cameronsjo/beadspace)** - Drop-in GitHub Pages dashboard with triage suggestions, priority/status breakdowns, and searchable issue table. Single HTML file, zero build dependencies, auto-deploys via GitHub Action. Built by [@cameronsjo](https://github.com/cameronsjo). (HTML/CSS/JS)
+```
+
+---
+
+## Discussion #276 Post
+
+### Beadspace — a drop-in dashboard for GitHub Pages
+
+Built this to scratch my own itch: I wanted a quick way to scan open issues and spot misprioritized work without leaving the browser.
+
+**What it does:**
+
+- Dashboard with stats, active issues sorted by priority, and auto-generated triage suggestions (flags stale P0/P1s, low-priority bugs, plan-worthy items without descriptions)
+- Searchable/sortable issues table with status filters
+- Pure CSS charts — no Chart.js, no D3, no external JS dependencies
+
+**How it works:**
+
+- Single `index.html` that fetches `issues.json` at load time
+- GitHub Action converts `.beads/issues.jsonl` to JSON array and deploys to Pages
+- Edit the HTML directly to customize — no build step needed
+
+**Drop-in recipe:**
+
+```bash
+mkdir -p docs/beadspace
+curl -sL https://raw.githubusercontent.com/cameronsjo/beadspace/main/index.html > docs/beadspace/index.html
+curl -sL https://raw.githubusercontent.com/cameronsjo/beadspace/main/workflows/beadspace.yml > .github/workflows/beadspace.yml
+bd export | jq -s '.' > docs/beadspace/issues.json
+gh api repos/{owner}/{repo}/pages -X POST -f "build_type=workflow"
+```
+
+Includes a `CLAUDE.md` so Claude (or any AI assistant) can customize the dashboard — covers the issue schema, CSS variables, and how to add views/panels.
+
+**Repo:** https://github.com/cameronsjo/beadspace
+**Live example:** https://cameronsjo.github.io/llm-council/
+
+Inspired by [@mattbeane](https://github.com/mattbeane)'s [beads-viz-prototype](https://github.com/mattbeane/beads-viz-prototype) — took the "single HTML file from bd export" concept and rebuilt it as a dynamic triage dashboard.

--- a/docs/beadspace/community-submission.md
+++ b/docs/beadspace/community-submission.md
@@ -28,12 +28,12 @@ Built this to scratch my own itch: I wanted a quick way to scan open issues and 
 - GitHub Action converts `.beads/issues.jsonl` to JSON array and deploys to Pages
 - Edit the HTML directly to customize — no build step needed
 
-**Drop-in recipe:**
+**Drop-in recipe** (replace `{owner}/{repo}` in the last command with your repo, e.g. `acme/widgets`):
 
 ```bash
 mkdir -p docs/beadspace
 curl -sL https://raw.githubusercontent.com/cameronsjo/beadspace/main/index.html > docs/beadspace/index.html
-curl -sL https://raw.githubusercontent.com/cameronsjo/beadspace/main/workflows/beadspace.yml > .github/workflows/beadspace.yml
+curl -sL https://raw.githubusercontent.com/cameronsjo/beadspace/main/.github/workflows/beadspace.yml > .github/workflows/beadspace.yml
 bd export | jq -s '.' > docs/beadspace/issues.json
 gh api repos/{owner}/{repo}/pages -X POST -f "build_type=workflow"
 ```

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: llm-council
+description: "Get started with LLM Council -- what it is, how to set it up, and how to use it"
+---
+
+
+Guide the user through getting started with **LLM Council**.
+
+## About
+
+LLM Council is a collaborative LLM deliberation system that queries multiple LLMs via OpenRouter, has them anonymously peer-review each other's responses, and synthesizes a final answer. It supports two modes: Council Mode (3-stage deliberation with peer ranking) and Arena Mode (multi-round structured debates). Fork of karpathy/llm-council with significant extensions.
+
+## Prerequisites
+
+Check that the user has the following installed/configured:
+
+- Python 3.10+ (`python3 --version`)
+- Node.js 18+ (`node --version`)
+- [uv](https://docs.astral.sh/uv/) for Python dependency management (`uv --version`)
+- An [OpenRouter API key](https://openrouter.ai/) (required)
+- Optionally: a [Tavily API key](https://tavily.com/) for web search
+- Optionally: Docker and Docker Compose for containerized deployment
+
+## Setup
+
+Walk the user through initial setup:
+
+1. Install all dependencies:
+
+   ```bash
+   make install
+   ```
+
+   This runs `uv sync` for the Python backend and `npm install` in `frontend/`.
+
+2. Copy the environment template and configure it:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Edit `.env` and set `OPENROUTER_API_KEY` to your OpenRouter key. Optionally set `TAVILY_API_KEY` for web search.
+
+3. Run `make help` to see all available targets.
+
+**Docker alternative:** If the user prefers Docker, they can run `docker compose up -d` after configuring `.env`. The app will be at http://localhost:3000.
+
+## First Use
+
+Guide the user through their first interaction with the product:
+
+1. Start the dev servers:
+
+   ```bash
+   make dev
+   ```
+
+   This launches the backend on `:8001` and the frontend on `:5173` in parallel.
+
+2. Open http://localhost:5173 in a browser.
+
+3. Type a question and hit Enter. The Council will:
+   - **Stage 1**: Query all configured models in parallel
+   - **Stage 2**: Have each model anonymously rank the others
+   - **Stage 3**: Synthesize a final answer via the Chairman model
+
+4. Switch to Arena Mode via the UI toggle for multi-round debates instead.
+
+## Key Files
+
+Point the user to the most important files for understanding the project:
+
+- `backend/config.py` -- Model configuration, environment variables, defaults
+- `backend/council.py` -- Core 3-stage deliberation logic (the heart of the app)
+- `backend/arena.py` -- Arena Mode debate orchestration
+- `backend/main.py` -- FastAPI app, SSE streaming endpoints, CORS config
+- `frontend/src/App.jsx` -- Main React orchestration component
+- `Makefile` -- All build/run/lint targets (`make help` to list)
+- `.env.example` -- All supported environment variables
+
+## Common Tasks
+
+- **Run in development**: `make dev` (starts backend + frontend in parallel)
+- **Build for production**: `make build` (builds frontend static assets)
+- **Run with Docker**: `make docker` (builds and runs via Docker Compose)
+- **Run linters**: `make lint` (ruff for Python, eslint for frontend)
+- **Fix lint issues**: `make lint-fix`
+- **Run the TUI client**: `make tui` (terminal UI alternative to the web frontend)

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: llm-council
+name: onboard
 description: "Get started with LLM Council -- what it is, how to set it up, and how to use it"
 ---
 
@@ -43,7 +43,7 @@ Walk the user through initial setup:
 
 3. Run `make help` to see all available targets.
 
-**Docker alternative:** If the user prefers Docker, they can run `docker compose up -d` after configuring `.env`. The app will be at http://localhost:3000.
+**Docker alternative:** If the user prefers Docker, they can run `make docker` (which executes `docker compose up --build`) after configuring `.env`. The app will be at http://localhost:3000.
 
 ## First Use
 


### PR DESCRIPTION
## Summary

Three small housekeeping commits bundled together:

1. **`.beads/.gitignore`** — ignore Dolt embedded storage (`embeddeddolt/`, `backup/`) and runtime artifacts (`daemon-error`). Also patches the legacy pre-commit hook in `.git/hooks/` to detect the Dolt backend by directory presence — without this, the bd 1.0.0 upgrade left every commit failing with \`unknown command sync\`.
2. **Claude Code plugin scaffold** — new \`.claude-plugin/\` manifest and \`skills/onboard/SKILL.md\` that walks new users through prerequisites, setup, and first run.
3. **Beadspace community submission** — drafts the \`COMMUNITY_TOOLS.md\` entry and Discussion #276 post for submitting Beadspace to the beads community tools list.

## Test plan

- [x] No code paths changed — pure config/doc/scaffold
- [x] Pre-commit hook fix verified locally (commits now succeed on this branch)
- [ ] Reviewer to confirm scaffold structure matches Claude Code plugin conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered as a Claude marketplace plugin for enhanced accessibility and integration

* **Documentation**
  * Added Beadspace community tools documentation with capabilities overview and deployment instructions
  * Added comprehensive onboarding guide with installation steps, configuration requirements, and quick-start usage instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->