### PR TITLE
feat: council standings — persistent ELO ratings + leaderboard

### DIFF
--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -25,6 +25,36 @@ from .rankings_storage import record_stage2_matches
 logger = logging.getLogger(__name__)
 
 
+def _persist_stage2_matches_safely(
+    stage2_results: list[dict[str, Any]],
+    label_to_model: dict[str, str],
+    conversation_id: str,
+    user_id: str | None,
+) -> None:
+    """Persist Stage 2 matches without ever breaking the SSE stream.
+
+    Logs context (conversation_id, user_id) on failure so multi-user
+    triage doesn't require correlating timestamps. The broad ``except``
+    is deliberate (BLE001) — rankings persistence is strictly best-effort
+    and must not propagate any exception class up the streaming pipeline.
+    """
+    try:
+        recorded = record_stage2_matches(
+            stage2_results, label_to_model,
+            conversation_id=conversation_id,
+            user_id=user_id,
+        )
+        logger.info(
+            "Recorded %d pairwise matches. ConversationId: %s, UserId: %s",
+            recorded, conversation_id, user_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort; never fail the stream
+        logger.warning(
+            "rankings persist failed. ConversationId: %s, UserId: %s, Error: %s",
+            conversation_id, user_id, exc, exc_info=True,
+        )
+
+
 def _extract_stage_data(
     msg: dict[str, Any],
 ) -> tuple[list[dict[str, Any]] | None, list[dict[str, Any]] | None]:
@@ -328,20 +358,9 @@ async def run_council_pipeline(
         aggregate_rankings = calculate_aggregate_rankings(
             stage2_results, label_to_model
         )
-        # Tap point for persistent ELO ratings — wrapped in try/except so a
-        # storage failure never breaks the streaming response.
-        try:
-            recorded = record_stage2_matches(
-                stage2_results, label_to_model,
-                conversation_id=input.conversation_id,
-                user_id=input.user_id,
-            )
-            logger.info(
-                "Recorded %d pairwise matches for conversation %s",
-                recorded, input.conversation_id,
-            )
-        except Exception as exc:
-            logger.warning("rankings persist failed: %s", exc, exc_info=True)
+        _persist_stage2_matches_safely(
+            stage2_results, label_to_model, input.conversation_id, input.user_id,
+        )
         stage2_duration = time.monotonic() - stage2_start
         logger.info(
             "Stage 2 complete. ConversationId: %s, Rankings: %d/%d, Errors: %d, Duration: %.2fs",
@@ -619,6 +638,9 @@ async def retry_rankings_pipeline(
             user_query, stage1_results, council_models
         )
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
+        _persist_stage2_matches_safely(
+            stage2_results, label_to_model, conversation_id, user_id,
+        )
         metadata = {
             "label_to_model": label_to_model,
             "aggregate_rankings": aggregate_rankings,
@@ -773,6 +795,9 @@ async def retry_all_pipeline(
             user_query, stage1_results, council_models
         )
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
+        _persist_stage2_matches_safely(
+            stage2_results, label_to_model, conversation_id, user_id,
+        )
         metadata = {
             "label_to_model": label_to_model,
             "aggregate_rankings": aggregate_rankings,

--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -20,6 +20,7 @@ from .council import (
     stage3_synthesize_final,
 )
 from .openrouter import ModelError, is_model_error
+from .rankings_storage import record_stage2_matches
 
 logger = logging.getLogger(__name__)
 
@@ -327,6 +328,20 @@ async def run_council_pipeline(
         aggregate_rankings = calculate_aggregate_rankings(
             stage2_results, label_to_model
         )
+        # Tap point for persistent ELO ratings — wrapped in try/except so a
+        # storage failure never breaks the streaming response.
+        try:
+            recorded = record_stage2_matches(
+                stage2_results, label_to_model,
+                conversation_id=input.conversation_id,
+                user_id=input.user_id,
+            )
+            logger.info(
+                "Recorded %d pairwise matches for conversation %s",
+                recorded, input.conversation_id,
+            )
+        except Exception as exc:
+            logger.warning("rankings persist failed: %s", exc, exc_info=True)
         stage2_duration = time.monotonic() - stage2_start
         logger.info(
             "Stage 2 complete. ConversationId: %s, Rankings: %d/%d, Errors: %d, Duration: %.2fs",

--- a/backend/elo.py
+++ b/backend/elo.py
@@ -88,22 +88,24 @@ def apply_match(
         loser: Model id that ranked lower.
         timestamp: ISO 8601 timestamp to record on both entries.
 
-    No-op when winner == loser. Self-matches would alias `w` and `l` to
-    the same dict and double-increment `games`, silently corrupting state.
-    Stray self-pairs from upstream parsing should be ignored, not recorded.
+    No-op when winner == loser. Self-matches would alias both state dicts
+    and double-increment `games`, silently corrupting state. Stray self-pairs
+    from upstream parsing should be ignored, not recorded.
     """
     if winner == loser:
         return
-    w = ratings.setdefault(
+    winner_state = ratings.setdefault(
         winner, {"rating": INITIAL_RATING, "games": 0, "last_updated": timestamp}
     )
-    l = ratings.setdefault(
+    loser_state = ratings.setdefault(
         loser, {"rating": INITIAL_RATING, "games": 0, "last_updated": timestamp}
     )
-    new_w, new_l = update_pair(w["rating"], l["rating"], score_a=1.0)
-    w["rating"] = new_w
-    w["games"] += 1
-    w["last_updated"] = timestamp
-    l["rating"] = new_l
-    l["games"] += 1
-    l["last_updated"] = timestamp
+    new_winner, new_loser = update_pair(
+        winner_state["rating"], loser_state["rating"], score_a=1.0,
+    )
+    winner_state["rating"] = new_winner
+    winner_state["games"] += 1
+    winner_state["last_updated"] = timestamp
+    loser_state["rating"] = new_loser
+    loser_state["games"] += 1
+    loser_state["last_updated"] = timestamp

--- a/backend/elo.py
+++ b/backend/elo.py
@@ -87,7 +87,13 @@ def apply_match(
         winner: Model id that ranked higher.
         loser: Model id that ranked lower.
         timestamp: ISO 8601 timestamp to record on both entries.
+
+    No-op when winner == loser. Self-matches would alias `w` and `l` to
+    the same dict and double-increment `games`, silently corrupting state.
+    Stray self-pairs from upstream parsing should be ignored, not recorded.
     """
+    if winner == loser:
+        return
     w = ratings.setdefault(
         winner, {"rating": INITIAL_RATING, "games": 0, "last_updated": timestamp}
     )

--- a/backend/elo.py
+++ b/backend/elo.py
@@ -1,0 +1,103 @@
+"""ELO rating calculations for council model peer rankings.
+
+Pure functions only — no I/O, no global state. All persistence lives in
+rankings_storage. This module is the math.
+"""
+
+from typing import Any
+
+# Standard ELO constants. K=32 is the classic chess starting K-factor;
+# good calibration for systems with limited data and rotating rosters.
+INITIAL_RATING = 1500.0
+K_FACTOR = 32.0
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Expected probability that A beats B given current ratings.
+
+    Standard ELO logistic formula: each 400 rating points = 10x odds.
+    Returns a value in (0, 1). Symmetric: expected_score(a, b) + expected_score(b, a) == 1.
+    """
+    return 1.0 / (1.0 + 10.0 ** ((rating_b - rating_a) / 400.0))
+
+
+def update_pair(
+    rating_a: float, rating_b: float, score_a: float, k: float = K_FACTOR
+) -> tuple[float, float]:
+    """Update both ratings after a match.
+
+    Args:
+        rating_a: Current rating of player A.
+        rating_b: Current rating of player B.
+        score_a: Actual outcome for A — 1.0 win, 0.5 draw, 0.0 loss.
+        k: K-factor controlling adjustment magnitude.
+
+    Returns:
+        (new_rating_a, new_rating_b). Zero-sum: deltas are equal and opposite.
+    """
+    expected_a = expected_score(rating_a, rating_b)
+    delta = k * (score_a - expected_a)
+    return rating_a + delta, rating_b - delta
+
+
+def extract_pairwise(
+    parsed_ranking: list[str], label_to_model: dict[str, str]
+) -> list[tuple[str, str]]:
+    """Convert a single voter's ranked list into pairwise (winner, loser) tuples.
+
+    A ranking [A, B, C] yields (A>B, A>C, B>C) — every higher-ranked label
+    beats every lower-ranked label. Labels missing from label_to_model are
+    skipped (defensive against stray text in parsed output).
+
+    Args:
+        parsed_ranking: Ordered list of anonymous labels (e.g. ["Response A", "Response C"]).
+        label_to_model: Mapping from label to canonical model id.
+
+    Returns:
+        List of (winner_model, loser_model) tuples for every distinct pair
+        in rank order.
+    """
+    resolved: list[str] = []
+    for label in parsed_ranking:
+        model = label_to_model.get(label)
+        if model and model not in resolved:
+            resolved.append(model)
+
+    pairs: list[tuple[str, str]] = []
+    for i, winner in enumerate(resolved):
+        for loser in resolved[i + 1:]:
+            pairs.append((winner, loser))
+    return pairs
+
+
+def apply_match(
+    ratings: dict[str, dict[str, Any]],
+    winner: str,
+    loser: str,
+    timestamp: str,
+) -> None:
+    """Apply a single pairwise outcome to a ratings dict in place.
+
+    Initializes either model at INITIAL_RATING if unseen. Each match counts
+    as one game for both participants.
+
+    Args:
+        ratings: Mutable dict keyed by model id, values like
+                 {"rating": float, "games": int, "last_updated": iso8601}.
+        winner: Model id that ranked higher.
+        loser: Model id that ranked lower.
+        timestamp: ISO 8601 timestamp to record on both entries.
+    """
+    w = ratings.setdefault(
+        winner, {"rating": INITIAL_RATING, "games": 0, "last_updated": timestamp}
+    )
+    l = ratings.setdefault(
+        loser, {"rating": INITIAL_RATING, "games": 0, "last_updated": timestamp}
+    )
+    new_w, new_l = update_pair(w["rating"], l["rating"], score_a=1.0)
+    w["rating"] = new_w
+    w["games"] += 1
+    w["last_updated"] = timestamp
+    l["rating"] = new_l
+    l["games"] += 1
+    l["last_updated"] = timestamp

--- a/backend/elo.py
+++ b/backend/elo.py
@@ -63,11 +63,11 @@ def extract_pairwise(
         if model and model not in resolved:
             resolved.append(model)
 
-    pairs: list[tuple[str, str]] = []
-    for i, winner in enumerate(resolved):
-        for loser in resolved[i + 1:]:
-            pairs.append((winner, loser))
-    return pairs
+    return [
+        (winner, loser)
+        for i, winner in enumerate(resolved)
+        for loser in resolved[i + 1:]
+    ]
 
 
 def apply_match(

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,6 +85,7 @@ from .council_stream import (
 from .export import export_to_json, export_to_markdown
 from .models import fetch_available_models, invalidate_cache as invalidate_models_cache
 from .openrouter import close_shared_client
+from .rankings_storage import get_leaderboard, replay_history
 from .shutdown import shutdown_coordinator
 from .websearch import get_search_provider, is_web_search_available
 
@@ -347,6 +348,34 @@ async def refresh_available_models():
     invalidate_models_cache()
     models = await fetch_available_models()
     return {"models": models, "refreshed": True}
+
+
+@app.get("/api/rankings")
+async def get_rankings(user: User | None = Depends(get_optional_user)) -> dict[str, Any]:
+    """Council ELO leaderboard.
+
+    Returns models sorted by current rating, descending. Empty list if no
+    Stage 2 rounds have been recorded yet for this user (or globally when
+    auth is disabled).
+    """
+    user_id = user.username if user else None
+    return {"leaderboard": get_leaderboard(user_id)}
+
+
+@app.get("/api/rankings/history")
+async def get_rankings_history(
+    model: str | None = None,
+    user: User | None = Depends(get_optional_user),
+) -> dict[str, Any]:
+    """Per-model ELO trend over time, replayed from the match log.
+
+    Args:
+        model: optional model id to filter the response. The full log is
+               always replayed so opponent ratings are accurate; this just
+               trims the returned series.
+    """
+    user_id = user.username if user else None
+    return {"history": replay_history(user_id, model_filter=model)}
 
 
 @app.post("/api/attachments")

--- a/backend/rankings_storage.py
+++ b/backend/rankings_storage.py
@@ -18,7 +18,7 @@ import logging
 import os
 import re
 import tempfile
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -99,10 +99,8 @@ def _atomic_write_json(path: Path, data: Any) -> None:
             json.dump(data, f, indent=2)
         os.replace(tmp, path)
     except BaseException:
-        try:
+        with suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            pass
         raise
 
 

--- a/backend/rankings_storage.py
+++ b/backend/rankings_storage.py
@@ -1,0 +1,238 @@
+"""Persistent storage for council ELO ratings.
+
+Two files per user:
+  - matches.jsonl  — append-only source of truth, one pairwise comparison per line
+  - ratings.json   — derived current state, atomic-write under the same lock
+
+Ratings can be fully reconstructed from matches.jsonl by replaying every line.
+That's the safety net: if ratings.json is ever corrupted or out of sync, delete
+it and `load_ratings()` won't break — the next match append rebuilds it.
+
+Mirrors backend/storage.py patterns: fcntl exclusive locking around the
+read-modify-write window, atomic writes via tempfile+os.replace.
+"""
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import DATA_BASE_DIR
+from .elo import INITIAL_RATING, apply_match, extract_pairwise
+
+logger = logging.getLogger(__name__)
+
+RATINGS_VERSION = 1
+
+
+def _rankings_dir(user_id: str | None) -> Path:
+    """Resolve the per-user (or global) rankings directory."""
+    if user_id:
+        return Path(DATA_BASE_DIR) / "users" / user_id / "rankings"
+    return Path(DATA_BASE_DIR) / "rankings"
+
+
+def _matches_path(user_id: str | None) -> Path:
+    return _rankings_dir(user_id) / "matches.jsonl"
+
+
+def _ratings_path(user_id: str | None) -> Path:
+    return _rankings_dir(user_id) / "ratings.json"
+
+
+def _lock_path(user_id: str | None) -> Path:
+    return _rankings_dir(user_id) / ".lock"
+
+
+@contextmanager
+def _rankings_lock(user_id: str | None = None):
+    """Exclusive lock for the rankings directory.
+
+    Same pattern as storage._pending_lock — one lock guards both files
+    so the matches.jsonl append and ratings.json rewrite happen atomically
+    relative to each other.
+    """
+    rdir = _rankings_dir(user_id)
+    rdir.mkdir(parents=True, exist_ok=True)
+    lock_fd = open(_lock_path(user_id), "w")
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        lock_fd.close()
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    """Write JSON atomically: tempfile in same dir + os.replace."""
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def load_ratings(user_id: str | None = None) -> dict[str, Any]:
+    """Load current ratings. Returns empty container if no file yet."""
+    path = _ratings_path(user_id)
+    if not path.exists():
+        return {"version": RATINGS_VERSION, "ratings": {}}
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("ratings.json unreadable for user=%s: %s", user_id, exc)
+        return {"version": RATINGS_VERSION, "ratings": {}}
+
+
+def record_stage2_matches(
+    stage2_results: list[dict[str, Any]],
+    label_to_model: dict[str, str],
+    conversation_id: str,
+    user_id: str | None = None,
+) -> int:
+    """Persist all pairwise comparisons from a Stage 2 round.
+
+    Each voter's parsed_ranking is converted to (winner, loser) pairs and
+    appended to matches.jsonl. Ratings.json is updated in the same critical
+    section so readers never observe a state where the JSONL has more matches
+    than the ratings reflect.
+
+    A voter's own response is included in the rankings (Stage 2 doesn't tell
+    voters which response is theirs), so we don't filter self-rankings.
+
+    Args:
+        stage2_results: list of dicts with at least {model, parsed_ranking}.
+        label_to_model: anonymized-label → canonical-model mapping for this round.
+        conversation_id: source conversation id (recorded for traceability).
+        user_id: optional username for per-user isolation.
+
+    Returns:
+        Number of pairwise matches recorded. Zero is a valid outcome
+        (e.g., all voters failed to produce parseable rankings).
+    """
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    pending_pairs: list[tuple[str, str, str]] = []  # (voter, winner, loser)
+    for ranking in stage2_results:
+        voter = ranking.get("model")
+        parsed = ranking.get("parsed_ranking") or []
+        if not voter or not parsed:
+            continue
+        for winner, loser in extract_pairwise(parsed, label_to_model):
+            pending_pairs.append((voter, winner, loser))
+
+    if not pending_pairs:
+        return 0
+
+    with _rankings_lock(user_id):
+        # 1. Append to JSONL — source of truth.
+        matches_file = _matches_path(user_id)
+        matches_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(matches_file, "a") as f:
+            for voter, winner, loser in pending_pairs:
+                record = {
+                    "ts": timestamp,
+                    "conversation_id": conversation_id,
+                    "voter": voter,
+                    "winner": winner,
+                    "loser": loser,
+                }
+                f.write(json.dumps(record) + "\n")
+
+        # 2. Update derived ratings.json.
+        state = load_ratings(user_id)
+        ratings = state.setdefault("ratings", {})
+        for _voter, winner, loser in pending_pairs:
+            apply_match(ratings, winner, loser, timestamp)
+        state["version"] = RATINGS_VERSION
+        _atomic_write_json(_ratings_path(user_id), state)
+
+    return len(pending_pairs)
+
+
+def get_leaderboard(user_id: str | None = None) -> list[dict[str, Any]]:
+    """Return current ratings as a sorted leaderboard.
+
+    Sorted by rating descending, ties broken by games played descending
+    (more games = more confidence in the rating).
+    """
+    state = load_ratings(user_id)
+    ratings = state.get("ratings", {})
+    rows = [
+        {
+            "model": model,
+            "rating": round(info.get("rating", INITIAL_RATING), 1),
+            "games": info.get("games", 0),
+            "last_updated": info.get("last_updated"),
+        }
+        for model, info in ratings.items()
+    ]
+    rows.sort(key=lambda r: (-r["rating"], -r["games"]))
+    for rank, row in enumerate(rows, start=1):
+        row["rank"] = rank
+    return rows
+
+
+def replay_history(
+    user_id: str | None = None, model_filter: str | None = None
+) -> dict[str, list[dict[str, Any]]]:
+    """Replay matches.jsonl to produce per-model rating timelines.
+
+    Walks the entire log applying ELO updates from scratch. After each match,
+    snapshots the current rating of both participants. Output is suitable
+    for a line chart with one series per model.
+
+    Args:
+        user_id: optional username for per-user isolation.
+        model_filter: if set, only return that model's series (still replays
+                      the whole log so opponents' ratings are accurate).
+
+    Returns:
+        {model_id: [{ts, rating, games}, ...]}. Empty dict if no log yet.
+    """
+    path = _matches_path(user_id)
+    if not path.exists():
+        return {}
+
+    ratings: dict[str, dict[str, Any]] = {}
+    history: dict[str, list[dict[str, Any]]] = {}
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("skipping malformed match record")
+                continue
+            winner = rec.get("winner")
+            loser = rec.get("loser")
+            ts = rec.get("ts")
+            if not (winner and loser and ts):
+                continue
+            apply_match(ratings, winner, loser, ts)
+            for model in (winner, loser):
+                if model_filter and model != model_filter:
+                    continue
+                history.setdefault(model, []).append({
+                    "ts": ts,
+                    "rating": round(ratings[model]["rating"], 1),
+                    "games": ratings[model]["games"],
+                })
+    return history

--- a/backend/rankings_storage.py
+++ b/backend/rankings_storage.py
@@ -106,6 +106,61 @@ def _atomic_write_json(path: Path, data: Any) -> None:
         raise
 
 
+def _is_valid_ratings_state(state: Any) -> bool:
+    """Validate the shape of a loaded ratings.json payload.
+
+    Parseable JSON isn't enough — a file with ``[]`` or
+    ``{"ratings": []}`` parses cleanly but breaks every downstream
+    operation. We treat any shape mismatch as corruption and let the
+    caller rebuild from the log.
+    """
+    if not isinstance(state, dict):
+        return False
+    ratings = state.get("ratings")
+    if not isinstance(ratings, dict):
+        return False
+    for entry in ratings.values():
+        if not isinstance(entry, dict):
+            return False
+        if not isinstance(entry.get("rating"), (int, float)):
+            return False
+        if not isinstance(entry.get("games"), int):
+            return False
+    return True
+
+
+def _count_log_matches(user_id: str | None) -> int:
+    """Count the well-formed (winner, loser, ts) records in the match log."""
+    path = _matches_path(user_id)
+    if not path.exists():
+        return 0
+    try:
+        with open(path) as f:
+            count = 0
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("winner") and rec.get("loser") and rec.get("ts"):
+                    count += 1
+            return count
+    except OSError as exc:
+        logger.warning("match log unreadable for user=%s: %s", user_id, exc)
+        return 0
+
+
+def _ratings_total_games(state: dict[str, Any]) -> int:
+    """Sum the games counter across all models. Each match contributes 2 (winner+loser)."""
+    return sum(
+        entry.get("games", 0)
+        for entry in state.get("ratings", {}).values()
+    )
+
+
 def _rebuild_ratings_from_log(user_id: str | None) -> dict[str, Any]:
     """Reconstruct ratings.json state by replaying matches.jsonl from scratch.
 
@@ -139,22 +194,50 @@ def _rebuild_ratings_from_log(user_id: str | None) -> dict[str, Any]:
 def load_ratings(user_id: str | None = None) -> dict[str, Any]:
     """Load current ratings.
 
-    If ratings.json is missing or corrupt, rebuilds from matches.jsonl
-    so the "matches.jsonl is authoritative" invariant always holds.
-    Returns the empty container only when neither file exists.
+    Falls back to rebuilding from matches.jsonl in three cases, all of
+    which preserve the "matches.jsonl is authoritative" invariant:
+    1. ratings.json is missing entirely.
+    2. ratings.json is unreadable or unparseable (OSError, JSONDecodeError).
+    3. ratings.json parses but has the wrong shape (validator rejects it).
+    4. ratings.json appears stale relative to the match log — i.e. the log
+       has more matches than the ratings reflect, suggesting a crash between
+       the JSONL append and the ratings.json write. Without this check the
+       leaderboard would silently miss those matches forever.
     """
     path = _ratings_path(user_id)
     if not path.exists():
         return _rebuild_ratings_from_log(user_id)
+
     try:
         with open(path) as f:
-            return json.load(f)
+            state = json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning(
             "ratings.json unreadable for user=%s: %s; rebuilding from match log",
             user_id, exc,
         )
         return _rebuild_ratings_from_log(user_id)
+
+    if not _is_valid_ratings_state(state):
+        logger.warning(
+            "ratings.json has invalid shape for user=%s; rebuilding from match log",
+            user_id,
+        )
+        return _rebuild_ratings_from_log(user_id)
+
+    # Staleness check: each match in the log contributes 2 to total games
+    # (winner + loser, both incremented). Drift indicates the writer crashed
+    # mid-write and ratings.json never caught up to the authoritative log.
+    expected_games = _count_log_matches(user_id) * 2
+    if _ratings_total_games(state) < expected_games:
+        logger.warning(
+            "ratings.json stale relative to match log for user=%s "
+            "(games=%d, expected≥%d); rebuilding",
+            user_id, _ratings_total_games(state), expected_games,
+        )
+        return _rebuild_ratings_from_log(user_id)
+
+    return state
 
 
 def record_stage2_matches(
@@ -275,28 +358,36 @@ def replay_history(
     ratings: dict[str, dict[str, Any]] = {}
     history: dict[str, list[dict[str, Any]]] = {}
 
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("skipping malformed match record")
-                continue
-            winner = rec.get("winner")
-            loser = rec.get("loser")
-            ts = rec.get("ts")
-            if not (winner and loser and ts):
-                continue
-            apply_match(ratings, winner, loser, ts)
-            for model in (winner, loser):
-                if model_filter and model != model_filter:
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
                     continue
-                history.setdefault(model, []).append({
-                    "ts": ts,
-                    "rating": round(ratings[model]["rating"], 1),
-                    "games": ratings[model]["games"],
-                })
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("skipping malformed match record")
+                    continue
+                winner = rec.get("winner")
+                loser = rec.get("loser")
+                ts = rec.get("ts")
+                if not (winner and loser and ts):
+                    continue
+                apply_match(ratings, winner, loser, ts)
+                for model in (winner, loser):
+                    if model_filter and model != model_filter:
+                        continue
+                    history.setdefault(model, []).append({
+                        "ts": ts,
+                        "rating": round(ratings[model]["rating"], 1),
+                        "games": ratings[model]["games"],
+                    })
+    except OSError as exc:
+        # Degrade gracefully: callers (the /api/rankings/history endpoint)
+        # should still get a meaningful empty response rather than a 500.
+        logger.warning(
+            "match log read failed mid-replay for user=%s: %s",
+            user_id, exc,
+        )
     return history

--- a/backend/rankings_storage.py
+++ b/backend/rankings_storage.py
@@ -16,6 +16,7 @@ import fcntl
 import json
 import logging
 import os
+import re
 import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -30,10 +31,30 @@ logger = logging.getLogger(__name__)
 RATINGS_VERSION = 1
 
 
+_USER_ID_RE = re.compile(r"^[A-Za-z0-9_.\-@]+$")
+
+
+def _safe_user_id(user_id: str | None) -> str | None:
+    """Validate that a user_id is safe to interpolate into a filesystem path.
+
+    Rejects empty strings, anything containing path separators, ``..``,
+    or characters outside a conservative allowlist (alnum, underscore,
+    dash, dot, at-sign — covers usernames and email-style identifiers).
+    Returns the user_id on success, raises ValueError on rejection.
+    Returns None unchanged for the unauthenticated case.
+    """
+    if user_id is None:
+        return None
+    if not user_id or not _USER_ID_RE.match(user_id) or ".." in user_id:
+        raise ValueError(f"Unsafe user_id for filesystem path: {user_id!r}")
+    return user_id
+
+
 def _rankings_dir(user_id: str | None) -> Path:
     """Resolve the per-user (or global) rankings directory."""
-    if user_id:
-        return Path(DATA_BASE_DIR) / "users" / user_id / "rankings"
+    safe = _safe_user_id(user_id)
+    if safe:
+        return Path(DATA_BASE_DIR) / "users" / safe / "rankings"
     return Path(DATA_BASE_DIR) / "rankings"
 
 
@@ -85,17 +106,55 @@ def _atomic_write_json(path: Path, data: Any) -> None:
         raise
 
 
+def _rebuild_ratings_from_log(user_id: str | None) -> dict[str, Any]:
+    """Reconstruct ratings.json state by replaying matches.jsonl from scratch.
+
+    Used as a fallback when ratings.json is missing or unreadable but the
+    match log is intact. Preserves the "matches.jsonl is authoritative"
+    invariant: the leaderboard never silently empties when ratings.json
+    disappears, as long as the log survives.
+    """
+    matches = _matches_path(user_id)
+    ratings: dict[str, dict[str, Any]] = {}
+    if not matches.exists():
+        return {"version": RATINGS_VERSION, "ratings": ratings}
+    try:
+        with open(matches) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                winner, loser, ts = rec.get("winner"), rec.get("loser"), rec.get("ts")
+                if winner and loser and ts:
+                    apply_match(ratings, winner, loser, ts)
+    except OSError as exc:
+        logger.warning("matches.jsonl unreadable for user=%s: %s", user_id, exc)
+    return {"version": RATINGS_VERSION, "ratings": ratings}
+
+
 def load_ratings(user_id: str | None = None) -> dict[str, Any]:
-    """Load current ratings. Returns empty container if no file yet."""
+    """Load current ratings.
+
+    If ratings.json is missing or corrupt, rebuilds from matches.jsonl
+    so the "matches.jsonl is authoritative" invariant always holds.
+    Returns the empty container only when neither file exists.
+    """
     path = _ratings_path(user_id)
     if not path.exists():
-        return {"version": RATINGS_VERSION, "ratings": {}}
+        return _rebuild_ratings_from_log(user_id)
     try:
         with open(path) as f:
             return json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("ratings.json unreadable for user=%s: %s", user_id, exc)
-        return {"version": RATINGS_VERSION, "ratings": {}}
+        logger.warning(
+            "ratings.json unreadable for user=%s: %s; rebuilding from match log",
+            user_id, exc,
+        )
+        return _rebuild_ratings_from_log(user_id)
 
 
 def record_stage2_matches(
@@ -139,7 +198,14 @@ def record_stage2_matches(
         return 0
 
     with _rankings_lock(user_id):
-        # 1. Append to JSONL — source of truth.
+        # 1. Load pre-existing ratings BEFORE writing the new matches.
+        # load_ratings() rebuilds from matches.jsonl when ratings.json is
+        # missing — if we loaded after appending we'd double-count the new
+        # records (rebuild sees them in the log AND we apply_match() below).
+        state = load_ratings(user_id)
+        ratings = state.setdefault("ratings", {})
+
+        # 2. Append to JSONL — source of truth.
         matches_file = _matches_path(user_id)
         matches_file.parent.mkdir(parents=True, exist_ok=True)
         with open(matches_file, "a") as f:
@@ -153,9 +219,7 @@ def record_stage2_matches(
                 }
                 f.write(json.dumps(record) + "\n")
 
-        # 2. Update derived ratings.json.
-        state = load_ratings(user_id)
-        ratings = state.setdefault("ratings", {})
+        # 3. Apply matches to the loaded state and persist.
         for _voter, winner, loser in pending_pairs:
             apply_match(ratings, winner, loser, timestamp)
         state["version"] = RATINGS_VERSION

--- a/docs/plans/2026-04-25-council-standings.md
+++ b/docs/plans/2026-04-25-council-standings.md
@@ -12,7 +12,7 @@ Every Council Stage 2 round produces rich peer-review signal: each model ranks a
 
 ## Architecture
 
-```
+```text
 Stage 2 result (council_stream.py:324)
         ↓
 record_stage2_matches()  ← new: extract pairwise comparisons, append to JSONL, update ratings
@@ -49,9 +49,10 @@ Mirrors `storage.py` patterns: `user_id` param, fcntl locking, atomic-write via 
   - Append all to `matches.jsonl` (single fcntl-locked append)
   - Update `ratings.json` (read-modify-write under same lock)
 - `load_ratings(user_id) -> dict` — leaderboard data
-- `replay_history(user_id, model_filter=None) -> list[dict]` — walks JSONL, yields `{timestamp, model, rating}` snapshots
+- `replay_history(user_id, model_filter=None) -> dict[str, list[dict]]` — walks JSONL, returns `{model_id: [{ts, rating, games}, ...]}` per-model snapshots
 
 **Match record schema** (one JSON object per line):
+
 ```json
 {"ts": "2026-04-25T18:52:00Z", "conversation_id": "abc", "voter": "openai/gpt-5.1", "winner": "anthropic/claude-opus", "loser": "google/gemini-pro"}
 ```
@@ -89,7 +90,7 @@ async def get_rankings_history(
     model: str | None = None,
     user: User | None = Depends(get_optional_user)
 ) -> dict
-    # Returns {model: [{ts, rating}, ...]} — all models, or filtered to one
+    # Returns {history: {model: [{ts, rating, games}, ...]}} — all models, or filtered to one
 ```
 
 Both readonly, both honor `user_id = user.username if user else None`.

--- a/docs/plans/2026-04-25-council-standings.md
+++ b/docs/plans/2026-04-25-council-standings.md
@@ -1,0 +1,215 @@
+# Council Standings — Persistent ELO Ratings
+
+## Context
+
+Every Council Stage 2 round produces rich peer-review signal: each model ranks all the others. Today that signal evaporates the moment the conversation renders. We can capture it cheaply and turn it into a longitudinal scoreboard — a "Standings" page that shows which models actually win the most peer reviews over time, and how individual models trend as their providers ship updates.
+
+**Why now:** the data is already shaped for this. `stage2_collect_rankings()` returns per-voter parsed rankings, and `calculate_aggregate_rankings()` already computes per-round summaries. We just need to persist the underlying pairwise comparisons and replay them as ELO ratings.
+
+**Intended outcome:** a new "Standings" view in the frontend backed by two new endpoints, fed by a single tap point in the council stream pipeline. No changes to the existing council flow, no schema migrations to existing storage.
+
+---
+
+## Architecture
+
+```
+Stage 2 result (council_stream.py:324)
+        ↓
+record_stage2_matches()  ← new: extract pairwise comparisons, append to JSONL, update ratings
+        ↓
+data/[users/{u}/]rankings/
+    matches.jsonl   ← append-only source of truth, one comparison per line
+    ratings.json    ← derived current state, atomic-write
+        ↓
+GET /api/rankings           → leaderboard from ratings.json
+GET /api/rankings/history   → time series replayed from matches.jsonl
+        ↓
+Standings.jsx (table + recharts trend)
+```
+
+**Scoring system:** ELO with K=32, initial rating 1500. Each Stage 2 round emits `V × C(N,2)` pairwise updates where V = voters, N = models — typically 4 voters × 6 pairs = 24 updates per round.
+
+**Per-user isolation** mirrors the existing conversation storage pattern via `user_id` parameter on every storage function.
+
+---
+
+## Backend Changes
+
+### New: `backend/elo.py`
+Pure-functions module. No I/O. Exports:
+- `INITIAL_RATING = 1500`, `K_FACTOR = 32`
+- `expected_score(rating_a, rating_b) -> float`
+- `update_pair(rating_a, rating_b, score_a) -> tuple[float, float]` — returns new ratings
+- `extract_pairwise(parsed_ranking, label_to_model) -> list[tuple[str, str]]` — `[(winner_model, loser_model), ...]` from a ranking list
+
+### New: `backend/rankings_storage.py`
+Mirrors `storage.py` patterns: `user_id` param, fcntl locking, atomic-write via tempfile+rename. Exports:
+- `record_stage2_matches(stage2_results, label_to_model, conversation_id, user_id)` — main entry point
+  - For each voter's `parsed_ranking`, extract pairwise comparisons
+  - Append all to `matches.jsonl` (single fcntl-locked append)
+  - Update `ratings.json` (read-modify-write under same lock)
+- `load_ratings(user_id) -> dict` — leaderboard data
+- `replay_history(user_id, model_filter=None) -> list[dict]` — walks JSONL, yields `{timestamp, model, rating}` snapshots
+
+**Match record schema** (one JSON object per line):
+```json
+{"ts": "2026-04-25T18:52:00Z", "conversation_id": "abc", "voter": "openai/gpt-5.1", "winner": "anthropic/claude-opus", "loser": "google/gemini-pro"}
+```
+
+**Ratings file schema:**
+```json
+{
+  "version": 1,
+  "ratings": {
+    "openai/gpt-5.1": {"rating": 1532.4, "games": 48, "last_updated": "2026-04-25T18:52:00Z"}
+  }
+}
+```
+
+### Tap point: `backend/council_stream.py:324-329`
+After `aggregate_rankings = calculate_aggregate_rankings(...)`, add:
+```python
+try:
+    record_stage2_matches(stage2_results, label_to_model, conversation_id, user_id)
+except Exception as exc:
+    logger.warning("rankings persist failed: %s", exc)  # never break the stream
+```
+Wrapped in try/except — rankings persistence must never fail the streaming response.
+
+### New endpoints in `backend/main.py`
+Inserted after the conversations block (~line 543), following existing route conventions:
+
+```python
+@app.get("/api/rankings")
+async def get_rankings(user: User | None = Depends(get_optional_user)) -> dict
+    # Returns sorted leaderboard: [{model, rating, games, rank, last_updated}, ...]
+
+@app.get("/api/rankings/history")
+async def get_rankings_history(
+    model: str | None = None,
+    user: User | None = Depends(get_optional_user)
+) -> dict
+    # Returns {model: [{ts, rating}, ...]} — all models, or filtered to one
+```
+
+Both readonly, both honor `user_id = user.username if user else None`.
+
+---
+
+## Frontend Changes
+
+### 1. New dependency
+`cd frontend && npm install recharts` — line/area charts, ~80KB gzipped, declarative React API.
+
+### 2. `frontend/src/stores/uiStore.js`
+Add view-switching state:
+```javascript
+currentView: 'chat',  // 'chat' | 'standings'
+setCurrentView: (view) => set({ currentView: view }),
+```
+
+### 3. `frontend/src/api.js`
+Add to the `api` export object:
+```javascript
+async getRankings() { return fetchJSON(`${API_BASE}/api/rankings`, {}, 'Failed to get rankings'); },
+async getRankingsHistory(model) {
+  const qs = model ? `?model=${encodeURIComponent(model)}` : '';
+  return fetchJSON(`${API_BASE}/api/rankings/history${qs}`, {}, 'Failed to get rankings history');
+},
+```
+
+### 4. `frontend/src/hooks/queries.js`
+Mirror existing query hook style:
+```javascript
+export function useRankings() {
+  return useQuery({ queryKey: ['rankings'], queryFn: api.getRankings, staleTime: 30_000 });
+}
+export function useRankingsHistory(model) {
+  return useQuery({
+    queryKey: ['rankingsHistory', model],
+    queryFn: () => api.getRankingsHistory(model),
+    staleTime: 30_000,
+  });
+}
+```
+
+### 5. `frontend/src/components/Sidebar.jsx`
+Add a nav row above the conversations list — two buttons: "Chat" and "Standings" — that call `setCurrentView`. Use existing CSS-variable styling (`--color-burgundy` for the active state).
+
+### 6. `frontend/src/App.jsx`
+Conditional render at the existing render point (~line 312):
+```jsx
+{currentView === 'standings' ? <Standings /> : <ChatInterface ... />}
+```
+
+### 7. New: `frontend/src/components/Standings.jsx` + `Standings.css`
+Two sections, both wrapped in the existing `.app` content container:
+- **Leaderboard table** — columns: rank, model, rating, games, last updated. Sortable by rating (default desc). Empty state when no matches yet.
+- **Trend chart** — recharts `<LineChart>` with one line per model, x-axis = match number (or timestamp if reasonable), y-axis = rating. Click a row in the table to filter to a single model.
+
+Use stage tokens from `index.css` for line colors so the chart fits the existing palette.
+
+---
+
+## Testing
+
+New test files mirroring existing pytest layout:
+
+- `tests/test_elo.py` — pure math. Verify `expected_score` symmetry, `update_pair` zero-sum property, K=32 calibration on known examples.
+- `tests/test_rankings_storage.py` — JSONL append idempotency under concurrent writes (use `_pending_lock` style fixture), ratings.json replay equivalence (replaying the log produces the same ratings as live updates).
+- `tests/test_rankings_api.py` — endpoint smoke: empty state returns `{}`, after one round leaderboard is sorted, history endpoint returns time series.
+
+No frontend tests (existing project has none for components).
+
+---
+
+## Verification
+
+End-to-end check after implementation:
+
+1. **Backend unit tests pass:** `make test` (or `uv run pytest tests/test_elo.py tests/test_rankings_storage.py tests/test_rankings_api.py -v`)
+2. **Live integration:**
+   - `make dev`
+   - Open http://localhost:5173, run a Council round with 4 models
+   - Inspect `data/rankings/matches.jsonl` — should have 24 lines (4 voters × 6 pairs)
+   - Inspect `data/rankings/ratings.json` — 4 models, all with `games > 0`, ratings sum to ~6000 (zero-sum invariant ± float drift)
+   - Click "Standings" in sidebar — leaderboard renders sorted by rating
+   - Run a second Council round — leaderboard updates, trend chart shows two data points per model
+3. **Auth-mode isolation:** with `LLMCOUNCIL_AUTH_ENABLED=true`, two simulated users see independent leaderboards (run from different `Remote-User` headers, verify `data/users/{u}/rankings/` directories exist separately).
+4. **Failure isolation:** delete write permissions on the rankings dir mid-run; the council stream still completes successfully (warning in logs, no SSE error).
+
+---
+
+## Out of Scope (YAGNI for v1)
+
+- **Backfilling historical conversations** — possible by re-reading existing JSON files but adds replay logic and edge cases. Punt to a one-shot CLI script later if useful.
+- **Arena Mode scoring** — debate rounds aren't ranked the same way. Separate design.
+- **Confidence intervals / Glicko-2** — ELO with K=32 is good enough until we have thousands of rounds.
+- **Voter-trust weighting** — circular and unjustified by current data.
+- **Model deprecation handling** — no UI to hide retired models. Add when it actually annoys us.
+
+---
+
+## Critical Files
+
+**Modify:**
+- `backend/council_stream.py` — single tap point, ~5 lines added
+- `backend/main.py` — two new endpoints
+- `frontend/src/api.js` — two new methods
+- `frontend/src/hooks/queries.js` — two new hooks
+- `frontend/src/stores/uiStore.js` — `currentView` slice
+- `frontend/src/components/Sidebar.jsx` — nav row
+- `frontend/src/App.jsx` — conditional render
+
+**Create:**
+- `backend/elo.py` — pure ELO math
+- `backend/rankings_storage.py` — JSONL + ratings persistence
+- `frontend/src/components/Standings.jsx` + `Standings.css`
+- `tests/test_elo.py`
+- `tests/test_rankings_storage.py`
+- `tests/test_rankings_api.py`
+
+**Reuse (no changes):**
+- `backend/council.py:621-661` — `calculate_aggregate_rankings()` already returns per-round summary; ELO module consumes the same `stage2_results` + `label_to_model` shape
+- `backend/storage.py:557-597` — fcntl locking + atomic write pattern, copied not abstracted
+- `backend/auth.py:185-197` — `get_optional_user` dependency wired identically

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.12"
       },
@@ -1029,6 +1030,42 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1419,6 +1456,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.95.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
@@ -1500,6 +1549,69 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -1586,6 +1698,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -2010,6 +2128,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2075,6 +2202,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2091,6 +2339,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -2157,6 +2411,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -2474,6 +2738,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2725,6 +2995,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2757,6 +3037,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4165,6 +4454,13 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -4192,6 +4488,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -4200,6 +4519,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -4267,6 +4631,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4494,6 +4864,12 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4716,6 +5092,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -4742,6 +5127,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.12"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from 'react';
 import { Menu } from 'lucide-react';
 import Sidebar from './components/Sidebar';
 import ChatInterface from './components/ChatInterface';
+import Standings from './components/Standings';
 import { api, AuthRedirectError } from './api';
 import { useConversationStream } from './hooks/useConversationStream';
 import { useUIStore } from './stores/uiStore';
@@ -25,6 +26,7 @@ function App() {
   const setAuthExpired = useUIStore((s) => s.setAuthExpired);
   const currentConversationId = useUIStore((s) => s.currentConversationId);
   const setCurrentConversationId = useUIStore((s) => s.setCurrentConversationId);
+  const currentView = useUIStore((s) => s.currentView);
   const mode = useUIStore((s) => s.mode);
   const setMode = useUIStore((s) => s.setMode);
   const arenaRoundCount = useUIStore((s) => s.arenaRoundCount);
@@ -343,21 +345,25 @@ function App() {
         onSelectConversation={handleSelectConversationMobile}
         onNewConversation={handleNewConversation}
       />
-      <ChatInterface
-        conversation={currentConversation}
-        isLoading={isLoading}
-        isExtendingDebate={isExtendingDebate}
-        onSendMessage={handleSendMessage}
-        onRetry={handleRetry}
-        onRetryInterrupted={handleRetryInterrupted}
-        onDismissInterrupted={handleDismissInterrupted}
-        onForkConversation={handleForkConversation}
-        onExtendDebate={handleExtendDebate}
-        onRetrySynthesis={handleRetrySynthesis}
-        onRetryRankings={handleRetryRankings}
-        onRetryAll={handleRetryAll}
-        onCancel={cancelStream}
-      />
+      {currentView === 'standings' ? (
+        <Standings />
+      ) : (
+        <ChatInterface
+          conversation={currentConversation}
+          isLoading={isLoading}
+          isExtendingDebate={isExtendingDebate}
+          onSendMessage={handleSendMessage}
+          onRetry={handleRetry}
+          onRetryInterrupted={handleRetryInterrupted}
+          onDismissInterrupted={handleDismissInterrupted}
+          onForkConversation={handleForkConversation}
+          onExtendDebate={handleExtendDebate}
+          onRetrySynthesis={handleRetrySynthesis}
+          onRetryRankings={handleRetryRankings}
+          onRetryAll={handleRetryAll}
+          onCancel={cancelStream}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -287,6 +287,22 @@ export const api = {
   },
 
   /**
+   * Council standings — leaderboard sorted by current ELO rating.
+   */
+  async getRankings() {
+    return fetchJSON(`${API_BASE}/api/rankings`, {}, 'Failed to get rankings');
+  },
+
+  /**
+   * Per-model ELO history. If `model` is provided, narrow the response to
+   * that single model; otherwise return all series.
+   */
+  async getRankingsHistory(model = null) {
+    const qs = model ? `?model=${encodeURIComponent(model)}` : '';
+    return fetchJSON(`${API_BASE}/api/rankings/history${qs}`, {}, 'Failed to get rankings history');
+  },
+
+  /**
    * List all conversations.
    */
   async listConversations() {

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -131,6 +131,40 @@
   transform: translateY(0);
 }
 
+.sidebar-views {
+  display: flex;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.sidebar-view-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.sidebar-view-btn:hover {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.sidebar-view-btn.active {
+  background: var(--color-burgundy);
+  border-color: var(--color-burgundy);
+  color: #fff;
+}
+
 .conversation-list {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Moon, Sun, Monitor, X } from 'lucide-react';
+import { Moon, Sun, Monitor, X, MessageSquare, Trophy } from 'lucide-react';
 import './Sidebar.css';
 import { ConversationItem, CouncilDisplay } from './sidebar/index.js';
 import ModelSelector from './ModelSelector';
@@ -22,6 +22,8 @@ export default function Sidebar({
   const chairmanModel = config?.chairman_model || '';
   const { data: userInfo } = useUserInfo();
   const { sidebarOpen, setSidebarOpen } = useUIStore();
+  const currentView = useUIStore((s) => s.currentView);
+  const setCurrentView = useUIStore((s) => s.setCurrentView);
 
   const deleteConversation = useDeleteConversation();
   const renameConversation = useRenameConversation();
@@ -141,6 +143,26 @@ export default function Sidebar({
         <button className="new-conversation-btn" onClick={onNewConversation}>
           + New Conversation
         </button>
+        <nav className="sidebar-views" aria-label="Top-level views">
+          <button
+            type="button"
+            className={`sidebar-view-btn ${currentView === 'chat' ? 'active' : ''}`}
+            onClick={() => setCurrentView('chat')}
+            aria-pressed={currentView === 'chat'}
+          >
+            <MessageSquare size={14} aria-hidden="true" />
+            <span>Chat</span>
+          </button>
+          <button
+            type="button"
+            className={`sidebar-view-btn ${currentView === 'standings' ? 'active' : ''}`}
+            onClick={() => setCurrentView('standings')}
+            aria-pressed={currentView === 'standings'}
+          >
+            <Trophy size={14} aria-hidden="true" />
+            <span>Standings</span>
+          </button>
+        </nav>
       </div>
 
       <div className="conversation-list">

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -1,0 +1,169 @@
+.standings {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-xl) var(--space-2xl);
+  background: var(--color-cream);
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+}
+
+.standings-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.standings-icon {
+  color: var(--color-gold-dark);
+  flex-shrink: 0;
+}
+
+.standings-header h1 {
+  font-family: var(--font-display);
+  font-size: 1.875rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.standings-subtitle {
+  margin: var(--space-xs) 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9375rem;
+}
+
+.standings-section {
+  margin-bottom: var(--space-2xl);
+}
+
+.standings-section h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 var(--space-md);
+  color: var(--color-burgundy);
+  letter-spacing: -0.01em;
+}
+
+.standings-empty,
+.standings-error {
+  padding: var(--space-lg);
+  background: var(--color-ivory);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 0.9375rem;
+  text-align: center;
+}
+
+.standings-error {
+  border-color: var(--color-burgundy-light);
+  background: rgba(168, 61, 77, 0.06);
+  color: var(--color-burgundy);
+}
+
+.standings-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-subtle);
+  font-size: 0.9375rem;
+}
+
+.standings-table thead {
+  background: var(--color-parchment);
+}
+
+.standings-table th {
+  text-align: left;
+  padding: var(--space-md) var(--space-lg);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.standings-table td {
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.standings-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.standings-table tbody tr {
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.standings-table tbody tr:hover {
+  background: var(--color-ivory);
+}
+
+.standings-table tbody tr.selected {
+  background: var(--color-stage2);
+}
+
+.standings-table .rank {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: var(--color-burgundy);
+  width: 60px;
+}
+
+.standings-table .model {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--color-text-primary);
+}
+
+.standings-table .num {
+  text-align: right;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.standings-table .ts {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.standings-filter-hint {
+  margin: var(--space-sm) 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  text-align: right;
+}
+
+.standings-chart {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg) var(--space-md) var(--space-md);
+  box-shadow: var(--shadow-subtle);
+}
+
+@media (max-width: 768px) {
+  .standings {
+    padding: var(--space-lg) var(--space-md);
+  }
+  .standings-table th,
+  .standings-table td {
+    padding: var(--space-sm);
+    font-size: 0.8125rem;
+  }
+  .standings-table .ts {
+    display: none;
+  }
+}

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -232,6 +232,10 @@
     padding: var(--space-sm);
     font-size: 0.8125rem;
   }
+  /* Hide both header and body for the "Last seen" column on small screens
+     to keep the columns aligned — hiding only .ts (body cells) leaves the
+     header behind and shifts the whole row by one column. */
+  .standings-table th:nth-child(5),
   .standings-table .ts {
     display: none;
   }

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -82,7 +82,7 @@
 
 .standings-table th {
   text-align: left;
-  padding: var(--space-md) var(--space-lg);
+  padding: 0;
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 0.875rem;
@@ -90,6 +90,48 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   border-bottom: 1px solid var(--color-border);
+}
+
+.sort-header-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  width: 100%;
+  padding: var(--space-md) var(--space-lg);
+  background: transparent;
+  border: none;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.standings-table th.num .sort-header-btn {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.sort-header-btn:hover {
+  background: var(--color-ivory);
+  color: var(--color-burgundy);
+}
+
+.sort-header-btn:focus-visible {
+  outline: 2px solid var(--color-burgundy);
+  outline-offset: -2px;
+}
+
+.sort-icon {
+  flex-shrink: 0;
+  color: var(--color-burgundy);
+}
+
+.sort-icon.inactive {
+  color: var(--color-text-muted);
+  opacity: 0.5;
 }
 
 .standings-table td {
@@ -108,6 +150,11 @@
 
 .standings-table tbody tr:hover {
   background: var(--color-ivory);
+}
+
+.standings-table tbody tr:focus-visible {
+  outline: 2px solid var(--color-burgundy);
+  outline-offset: -2px;
 }
 
 .standings-table tbody tr.selected {

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -144,7 +144,6 @@
 }
 
 .standings-table tbody tr {
-  cursor: pointer;
   transition: background var(--transition-fast);
 }
 
@@ -152,13 +151,36 @@
   background: var(--color-ivory);
 }
 
-.standings-table tbody tr:focus-visible {
-  outline: 2px solid var(--color-burgundy);
-  outline-offset: -2px;
-}
-
 .standings-table tbody tr.selected {
   background: var(--color-stage2);
+}
+
+.model-select-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.model-select-btn:hover {
+  color: var(--color-burgundy);
+  text-decoration: underline;
+}
+
+.model-select-btn:focus-visible {
+  outline: 2px solid var(--color-burgundy);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.model-select-btn[aria-pressed="true"] {
+  color: var(--color-burgundy);
+  font-weight: 600;
 }
 
 .standings-table .rank {

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   LineChart,
   Line,
@@ -9,7 +9,7 @@ import {
   Legend,
   CartesianGrid,
 } from 'recharts';
-import { Trophy } from 'lucide-react';
+import { Trophy, ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import { useRankings, useRankingsHistory } from '../hooks/queries';
 import './Standings.css';
 
@@ -21,6 +21,14 @@ const SERIES_COLORS = [
   'var(--color-burgundy)',
   'var(--color-gold-dark)',
   'var(--color-burgundy-light)',
+];
+
+const SORTABLE_COLUMNS = [
+  { key: 'rank', label: 'Rank', numeric: true },
+  { key: 'model', label: 'Model', numeric: false },
+  { key: 'rating', label: 'Rating', numeric: true },
+  { key: 'games', label: 'Games', numeric: true },
+  { key: 'last_updated', label: 'Last seen', numeric: false },
 ];
 
 function formatModel(id) {
@@ -42,36 +50,76 @@ function formatTimestamp(iso) {
   }
 }
 
+/**
+ * Group history snapshots by timestamp so each x-step represents one real
+ * match event, not one per-model snapshot. Without this grouping a single
+ * pairwise match (which updates two models simultaneously) would create
+ * two x-steps and distort the trend.
+ */
 function buildChartSeries(history) {
-  // history: { model: [{ts, rating, games}, ...] }
-  // Recharts wants a flat array with { idx, [model1]: r1, [model2]: r2, ... }
-  // We index by global match number across ALL series so lines align.
-  const allEvents = [];
+  const eventsByTs = new Map();
   Object.entries(history).forEach(([model, snapshots]) => {
     snapshots.forEach((s) => {
-      allEvents.push({ ...s, model });
+      if (!eventsByTs.has(s.ts)) eventsByTs.set(s.ts, {});
+      eventsByTs.get(s.ts)[model] = s.rating;
     });
   });
-  allEvents.sort((a, b) => (a.ts > b.ts ? 1 : a.ts < b.ts ? -1 : 0));
-
+  const sortedTs = [...eventsByTs.keys()].sort();
   const lastRatings = {};
-  const series = [];
-  allEvents.forEach((event, idx) => {
-    lastRatings[event.model] = event.rating;
-    series.push({ idx: idx + 1, ts: event.ts, ...lastRatings });
+  return sortedTs.map((ts, i) => {
+    Object.assign(lastRatings, eventsByTs.get(ts));
+    return { idx: i + 1, ts, ...lastRatings };
   });
-  return series;
 }
 
 export default function Standings() {
   const { data: rankingsData, isLoading: leaderboardLoading, error: leaderboardError } = useRankings();
   const [selectedModel, setSelectedModel] = useState(null);
+  const [sortConfig, setSortConfig] = useState({ key: 'rating', dir: 'desc' });
   const { data: historyData, isLoading: historyLoading } = useRankingsHistory(selectedModel);
 
   const leaderboard = rankingsData?.leaderboard || [];
   const history = historyData?.history || {};
-  const chartData = buildChartSeries(history);
+  const chartData = useMemo(() => buildChartSeries(history), [history]);
   const modelKeys = Object.keys(history);
+
+  const sortedLeaderboard = useMemo(() => {
+    const { key, dir } = sortConfig;
+    const sorted = [...leaderboard].sort((a, b) => {
+      const av = a[key];
+      const bv = b[key];
+      if (av === bv) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      const cmp = av < bv ? -1 : 1;
+      return dir === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [leaderboard, sortConfig]);
+
+  const handleSort = (key) => {
+    setSortConfig((prev) => {
+      if (prev.key !== key) {
+        // First click on a new column: numeric defaults to desc, text to asc.
+        const col = SORTABLE_COLUMNS.find((c) => c.key === key);
+        return { key, dir: col?.numeric ? 'desc' : 'asc' };
+      }
+      return { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' };
+    });
+  };
+
+  const toggleSelection = (model) => {
+    setSelectedModel((current) => (current === model ? null : model));
+  };
+
+  const sortIcon = (key) => {
+    if (sortConfig.key !== key) {
+      return <ArrowUpDown size={12} aria-hidden="true" className="sort-icon inactive" />;
+    }
+    return sortConfig.dir === 'asc'
+      ? <ArrowUp size={12} aria-hidden="true" className="sort-icon" />
+      : <ArrowDown size={12} aria-hidden="true" className="sort-icon" />;
+  };
 
   return (
     <main className="standings">
@@ -103,21 +151,48 @@ export default function Standings() {
           <table className="standings-table">
             <thead>
               <tr>
-                <th scope="col">Rank</th>
-                <th scope="col">Model</th>
-                <th scope="col" className="num">Rating</th>
-                <th scope="col" className="num">Games</th>
-                <th scope="col">Last seen</th>
+                {SORTABLE_COLUMNS.map((col) => {
+                  const isActive = sortConfig.key === col.key;
+                  return (
+                    <th
+                      key={col.key}
+                      scope="col"
+                      className={col.numeric ? 'num' : ''}
+                      aria-sort={
+                        isActive
+                          ? sortConfig.dir === 'asc' ? 'ascending' : 'descending'
+                          : 'none'
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="sort-header-btn"
+                        onClick={() => handleSort(col.key)}
+                      >
+                        <span>{col.label}</span>
+                        {sortIcon(col.key)}
+                      </button>
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody>
-              {leaderboard.map((row) => (
+              {sortedLeaderboard.map((row) => (
                 <tr
                   key={row.model}
                   className={selectedModel === row.model ? 'selected' : ''}
-                  onClick={() =>
-                    setSelectedModel(selectedModel === row.model ? null : row.model)
-                  }
+                  tabIndex={0}
+                  role="button"
+                  aria-pressed={selectedModel === row.model}
+                  aria-label={`Filter trend chart to ${formatModel(row.model)}`}
+                  onClick={() => toggleSelection(row.model)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      toggleSelection(row.model);
+                    }
+                  }}
                 >
                   <td className="rank">{row.rank}</td>
                   <td className="model" title={row.model}>{formatModel(row.model)}</td>
@@ -131,7 +206,7 @@ export default function Standings() {
         )}
         {selectedModel && (
           <p className="standings-filter-hint">
-            Filtered to <strong>{formatModel(selectedModel)}</strong> — click again to clear.
+            Filtered to <strong>{formatModel(selectedModel)}</strong> — click or press Enter on the row again to clear.
           </p>
         )}
       </section>

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -76,7 +76,11 @@ export default function Standings() {
   const { data: rankingsData, isLoading: leaderboardLoading, error: leaderboardError } = useRankings();
   const [selectedModel, setSelectedModel] = useState(null);
   const [sortConfig, setSortConfig] = useState({ key: 'rating', dir: 'desc' });
-  const { data: historyData, isLoading: historyLoading } = useRankingsHistory(selectedModel);
+  const {
+    data: historyData,
+    isLoading: historyLoading,
+    error: historyError,
+  } = useRankingsHistory(selectedModel);
 
   const leaderboard = rankingsData?.leaderboard || [];
   const history = historyData?.history || {};
@@ -133,16 +137,14 @@ export default function Standings() {
         </div>
       </header>
 
-      {leaderboardError && (
-        <div className="standings-error" role="alert">
-          Failed to load standings: {leaderboardError.message}
-        </div>
-      )}
-
       <section className="standings-section">
         <h2>Leaderboard</h2>
         {leaderboardLoading ? (
           <div className="standings-empty">Loading…</div>
+        ) : leaderboardError ? (
+          <div className="standings-error" role="alert">
+            Failed to load leaderboard: {leaderboardError.message || 'Unknown error'}
+          </div>
         ) : leaderboard.length === 0 ? (
           <div className="standings-empty">
             No matches recorded yet. Run a council round to start tracking ratings.
@@ -178,35 +180,38 @@ export default function Standings() {
               </tr>
             </thead>
             <tbody>
-              {sortedLeaderboard.map((row) => (
-                <tr
-                  key={row.model}
-                  className={selectedModel === row.model ? 'selected' : ''}
-                  tabIndex={0}
-                  role="button"
-                  aria-pressed={selectedModel === row.model}
-                  aria-label={`Filter trend chart to ${formatModel(row.model)}`}
-                  onClick={() => toggleSelection(row.model)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      toggleSelection(row.model);
-                    }
-                  }}
-                >
-                  <td className="rank">{row.rank}</td>
-                  <td className="model" title={row.model}>{formatModel(row.model)}</td>
-                  <td className="num">{Math.round(row.rating)}</td>
-                  <td className="num">{row.games}</td>
-                  <td className="ts">{formatTimestamp(row.last_updated)}</td>
-                </tr>
-              ))}
+              {sortedLeaderboard.map((row) => {
+                const isSelected = selectedModel === row.model;
+                return (
+                  <tr key={row.model} className={isSelected ? 'selected' : ''}>
+                    <td className="rank">{row.rank}</td>
+                    <td className="model" title={row.model}>
+                      <button
+                        type="button"
+                        className="model-select-btn"
+                        aria-pressed={isSelected}
+                        aria-label={
+                          isSelected
+                            ? `Clear filter on ${formatModel(row.model)}`
+                            : `Filter trend chart to ${formatModel(row.model)}`
+                        }
+                        onClick={() => toggleSelection(row.model)}
+                      >
+                        {formatModel(row.model)}
+                      </button>
+                    </td>
+                    <td className="num">{Math.round(row.rating)}</td>
+                    <td className="num">{row.games}</td>
+                    <td className="ts">{formatTimestamp(row.last_updated)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         )}
         {selectedModel && (
           <p className="standings-filter-hint">
-            Filtered to <strong>{formatModel(selectedModel)}</strong> — click or press Enter on the row again to clear.
+            Filtered to <strong>{formatModel(selectedModel)}</strong> — click the model name again to clear.
           </p>
         )}
       </section>
@@ -215,6 +220,10 @@ export default function Standings() {
         <h2>Trend</h2>
         {historyLoading ? (
           <div className="standings-empty">Loading…</div>
+        ) : historyError ? (
+          <div className="standings-error" role="alert">
+            Failed to load trend history: {historyError.message || 'Unknown error'}
+          </div>
         ) : modelKeys.length === 0 ? (
           <div className="standings-empty">No history yet.</div>
         ) : (

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  CartesianGrid,
+} from 'recharts';
+import { Trophy } from 'lucide-react';
+import { useRankings, useRankingsHistory } from '../hooks/queries';
+import './Standings.css';
+
+// Stage palette for line colors — falls back to burgundy/gold/sage tones for >3 series.
+const SERIES_COLORS = [
+  'var(--color-stage1-accent)',
+  'var(--color-stage2-accent)',
+  'var(--color-stage3-accent)',
+  'var(--color-burgundy)',
+  'var(--color-gold-dark)',
+  'var(--color-burgundy-light)',
+];
+
+function formatModel(id) {
+  // OpenRouter ids look like "anthropic/claude-sonnet-4.5" — show the right half.
+  return id?.split('/').slice(-1)[0] || id;
+}
+
+function formatTimestamp(iso) {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function buildChartSeries(history) {
+  // history: { model: [{ts, rating, games}, ...] }
+  // Recharts wants a flat array with { idx, [model1]: r1, [model2]: r2, ... }
+  // We index by global match number across ALL series so lines align.
+  const allEvents = [];
+  Object.entries(history).forEach(([model, snapshots]) => {
+    snapshots.forEach((s) => {
+      allEvents.push({ ...s, model });
+    });
+  });
+  allEvents.sort((a, b) => (a.ts > b.ts ? 1 : a.ts < b.ts ? -1 : 0));
+
+  const lastRatings = {};
+  const series = [];
+  allEvents.forEach((event, idx) => {
+    lastRatings[event.model] = event.rating;
+    series.push({ idx: idx + 1, ts: event.ts, ...lastRatings });
+  });
+  return series;
+}
+
+export default function Standings() {
+  const { data: rankingsData, isLoading: leaderboardLoading, error: leaderboardError } = useRankings();
+  const [selectedModel, setSelectedModel] = useState(null);
+  const { data: historyData, isLoading: historyLoading } = useRankingsHistory(selectedModel);
+
+  const leaderboard = rankingsData?.leaderboard || [];
+  const history = historyData?.history || {};
+  const chartData = buildChartSeries(history);
+  const modelKeys = Object.keys(history);
+
+  return (
+    <main className="standings">
+      <header className="standings-header">
+        <Trophy size={28} className="standings-icon" aria-hidden="true" />
+        <div>
+          <h1>Council Standings</h1>
+          <p className="standings-subtitle">
+            ELO ratings derived from Stage 2 peer rankings, replayed across every council round.
+          </p>
+        </div>
+      </header>
+
+      {leaderboardError && (
+        <div className="standings-error" role="alert">
+          Failed to load standings: {leaderboardError.message}
+        </div>
+      )}
+
+      <section className="standings-section">
+        <h2>Leaderboard</h2>
+        {leaderboardLoading ? (
+          <div className="standings-empty">Loading…</div>
+        ) : leaderboard.length === 0 ? (
+          <div className="standings-empty">
+            No matches recorded yet. Run a council round to start tracking ratings.
+          </div>
+        ) : (
+          <table className="standings-table">
+            <thead>
+              <tr>
+                <th scope="col">Rank</th>
+                <th scope="col">Model</th>
+                <th scope="col" className="num">Rating</th>
+                <th scope="col" className="num">Games</th>
+                <th scope="col">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leaderboard.map((row) => (
+                <tr
+                  key={row.model}
+                  className={selectedModel === row.model ? 'selected' : ''}
+                  onClick={() =>
+                    setSelectedModel(selectedModel === row.model ? null : row.model)
+                  }
+                >
+                  <td className="rank">{row.rank}</td>
+                  <td className="model" title={row.model}>{formatModel(row.model)}</td>
+                  <td className="num">{Math.round(row.rating)}</td>
+                  <td className="num">{row.games}</td>
+                  <td className="ts">{formatTimestamp(row.last_updated)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        {selectedModel && (
+          <p className="standings-filter-hint">
+            Filtered to <strong>{formatModel(selectedModel)}</strong> — click again to clear.
+          </p>
+        )}
+      </section>
+
+      <section className="standings-section">
+        <h2>Trend</h2>
+        {historyLoading ? (
+          <div className="standings-empty">Loading…</div>
+        ) : modelKeys.length === 0 ? (
+          <div className="standings-empty">No history yet.</div>
+        ) : (
+          <div className="standings-chart">
+            <ResponsiveContainer width="100%" height={360}>
+              <LineChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+                <CartesianGrid stroke="var(--color-border-light)" strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="idx"
+                  stroke="var(--color-text-muted)"
+                  label={{ value: 'Match #', position: 'insideBottom', offset: -2, fill: 'var(--color-text-muted)' }}
+                />
+                <YAxis
+                  stroke="var(--color-text-muted)"
+                  domain={['dataMin - 20', 'dataMax + 20']}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: 'var(--color-surface-elevated)',
+                    border: '1px solid var(--color-border)',
+                    borderRadius: 'var(--radius-sm)',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.8125rem',
+                  }}
+                  labelFormatter={(idx) => `Match ${idx}`}
+                  formatter={(value, name) => [Math.round(value), formatModel(name)]}
+                />
+                <Legend formatter={(value) => formatModel(value)} />
+                {modelKeys.map((model, i) => (
+                  <Line
+                    key={model}
+                    type="monotone"
+                    dataKey={model}
+                    stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+                    strokeWidth={2}
+                    dot={false}
+                    connectNulls
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -70,6 +70,22 @@ export function useCuratedModels() {
   });
 }
 
+export function useRankings() {
+  return useQuery({
+    queryKey: ['rankings'],
+    queryFn: () => api.getRankings(),
+    staleTime: 30_000,
+  });
+}
+
+export function useRankingsHistory(model) {
+  return useQuery({
+    queryKey: ['rankingsHistory', model],
+    queryFn: () => api.getRankingsHistory(model),
+    staleTime: 30_000,
+  });
+}
+
 // ── Mutations ────────────────────────────────────────────────────────────────
 
 export function useCreateConversation() {

--- a/frontend/src/stores/uiStore.js
+++ b/frontend/src/stores/uiStore.js
@@ -16,6 +16,10 @@ export const useUIStore = create((set) => ({
   mode: 'council',
   setMode: (mode) => set({ mode }),
 
+  // Top-level view ('chat' | 'standings')
+  currentView: 'chat',
+  setCurrentView: (view) => set({ currentView: view }),
+
   // Arena
   arenaRoundCount: 3,
   setArenaRoundCount: (count) => set({ arenaRoundCount: count }),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,5 +15,8 @@ os.environ.setdefault("OPENROUTER_API_KEY", "test-key-not-real")
 # test session. Any test that accidentally exercises a real I/O code path
 # (e.g., the rankings tap point inside the council stream pipeline) writes
 # to this temp dir instead of polluting developer state.
-_TEST_DATA_DIR = tempfile.mkdtemp(prefix="llmcouncil-tests-")
-os.environ.setdefault("LLMCOUNCIL_DATA_DIR", _TEST_DATA_DIR)
+# Only allocate a tempdir if the env var isn't already set — otherwise
+# CI runners or external orchestrators can pin the location, and we avoid
+# leaving orphan tempdirs on every test run.
+if "LLMCOUNCIL_DATA_DIR" not in os.environ:
+    os.environ["LLMCOUNCIL_DATA_DIR"] = tempfile.mkdtemp(prefix="llmcouncil-tests-")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,15 @@ preventing import errors from missing API keys.
 """
 
 import os
+import tempfile
 
 # Set required env vars BEFORE any backend imports happen.
 # pytest loads conftest.py before test modules, so this runs first.
 os.environ.setdefault("OPENROUTER_API_KEY", "test-key-not-real")
+
+# Redirect data writes away from the real ./data directory for the whole
+# test session. Any test that accidentally exercises a real I/O code path
+# (e.g., the rankings tap point inside the council stream pipeline) writes
+# to this temp dir instead of polluting developer state.
+_TEST_DATA_DIR = tempfile.mkdtemp(prefix="llmcouncil-tests-")
+os.environ.setdefault("LLMCOUNCIL_DATA_DIR", _TEST_DATA_DIR)

--- a/tests/test_elo.py
+++ b/tests/test_elo.py
@@ -130,3 +130,17 @@ class TestApplyMatch:
         # Sanity: K=32 is the classic value, drift if anyone changes it
         assert K_FACTOR == 32.0
         assert INITIAL_RATING == 1500.0
+
+    def test_self_match_is_no_op(self):
+        # winner == loser would alias to the same dict and double-increment games.
+        # Defensive: ignore the bad pair entirely.
+        ratings: dict = {}
+        apply_match(ratings, "model-x", "model-x", "t")
+        assert ratings == {}
+
+    def test_self_match_does_not_corrupt_existing_state(self):
+        ratings: dict = {}
+        apply_match(ratings, "alpha", "beta", "t1")
+        snapshot = {k: dict(v) for k, v in ratings.items()}
+        apply_match(ratings, "alpha", "alpha", "t2")
+        assert ratings == snapshot

--- a/tests/test_elo.py
+++ b/tests/test_elo.py
@@ -1,0 +1,132 @@
+"""Tests for the pure ELO math module."""
+
+import pytest
+
+from backend.elo import (
+    INITIAL_RATING,
+    K_FACTOR,
+    apply_match,
+    expected_score,
+    extract_pairwise,
+    update_pair,
+)
+
+
+class TestExpectedScore:
+    def test_equal_ratings_give_half(self):
+        assert expected_score(1500, 1500) == pytest.approx(0.5)
+
+    def test_symmetry(self):
+        # expected_score(a, b) + expected_score(b, a) == 1
+        for a, b in [(1500, 1700), (2000, 1200), (1234, 1567)]:
+            assert expected_score(a, b) + expected_score(b, a) == pytest.approx(1.0)
+
+    def test_higher_rated_favored(self):
+        assert expected_score(1700, 1500) > 0.5
+        assert expected_score(1300, 1500) < 0.5
+
+    def test_400_point_gap_is_10x_odds(self):
+        # Classic ELO calibration: 400 points = ~91% expected score
+        # because 10**1 / (1 + 10**1) ≈ 0.909
+        assert expected_score(1900, 1500) == pytest.approx(10 / 11, rel=1e-6)
+
+
+class TestUpdatePair:
+    def test_zero_sum(self):
+        # Whatever A gains, B loses. Total rating preserved.
+        a, b = 1600, 1400
+        new_a, new_b = update_pair(a, b, score_a=1.0)
+        assert (new_a + new_b) == pytest.approx(a + b)
+
+    def test_winner_gains_loser_drops(self):
+        new_a, new_b = update_pair(1500, 1500, score_a=1.0)
+        assert new_a > 1500
+        assert new_b < 1500
+        # K=32, equal ratings, win → +16/-16
+        assert new_a == pytest.approx(1516)
+        assert new_b == pytest.approx(1484)
+
+    def test_upset_moves_more(self):
+        # Underdog winning gets a bigger bump than favorite winning
+        underdog_new, _ = update_pair(1300, 1700, score_a=1.0)
+        favorite_new, _ = update_pair(1700, 1300, score_a=1.0)
+        assert (underdog_new - 1300) > (favorite_new - 1700)
+
+    def test_draw_balances_ratings(self):
+        # Higher-rated player loses ground in a draw against lower-rated.
+        new_a, new_b = update_pair(1700, 1300, score_a=0.5)
+        assert new_a < 1700
+        assert new_b > 1300
+
+    def test_k_factor_scales_change(self):
+        a1, _ = update_pair(1500, 1500, score_a=1.0, k=32)
+        a2, _ = update_pair(1500, 1500, score_a=1.0, k=16)
+        # Half K → half the delta
+        assert (a1 - 1500) == pytest.approx(2 * (a2 - 1500))
+
+
+class TestExtractPairwise:
+    def test_basic_three_way(self):
+        ranking = ["Response A", "Response B", "Response C"]
+        mapping = {"Response A": "model-a", "Response B": "model-b", "Response C": "model-c"}
+        pairs = extract_pairwise(ranking, mapping)
+        # 3 models = C(3,2) = 3 pairs: A>B, A>C, B>C
+        assert pairs == [("model-a", "model-b"), ("model-a", "model-c"), ("model-b", "model-c")]
+
+    def test_unknown_labels_skipped(self):
+        # Stray label not in mapping is dropped silently
+        ranking = ["Response A", "Response Z", "Response B"]
+        mapping = {"Response A": "model-a", "Response B": "model-b"}
+        pairs = extract_pairwise(ranking, mapping)
+        assert pairs == [("model-a", "model-b")]
+
+    def test_duplicate_labels_dedupe(self):
+        # Defensive: model parser sometimes repeats. Treat first occurrence as canonical.
+        ranking = ["Response A", "Response A", "Response B"]
+        mapping = {"Response A": "model-a", "Response B": "model-b"}
+        pairs = extract_pairwise(ranking, mapping)
+        assert pairs == [("model-a", "model-b")]
+
+    def test_empty_ranking(self):
+        assert extract_pairwise([], {}) == []
+
+    def test_single_label_no_pairs(self):
+        # Can't form a pair from one entry
+        pairs = extract_pairwise(["Response A"], {"Response A": "model-a"})
+        assert pairs == []
+
+
+class TestApplyMatch:
+    def test_initializes_unseen_models(self):
+        ratings: dict = {}
+        apply_match(ratings, "winner", "loser", "2026-04-25T18:00:00Z")
+        assert ratings["winner"]["games"] == 1
+        assert ratings["loser"]["games"] == 1
+        assert ratings["winner"]["rating"] > INITIAL_RATING
+        assert ratings["loser"]["rating"] < INITIAL_RATING
+
+    def test_increments_games(self):
+        ratings: dict = {}
+        apply_match(ratings, "a", "b", "t1")
+        apply_match(ratings, "a", "b", "t2")
+        assert ratings["a"]["games"] == 2
+        assert ratings["b"]["games"] == 2
+
+    def test_records_timestamp(self):
+        ratings: dict = {}
+        apply_match(ratings, "a", "b", "2026-04-25T18:00:00Z")
+        apply_match(ratings, "a", "b", "2026-04-25T19:00:00Z")
+        assert ratings["a"]["last_updated"] == "2026-04-25T19:00:00Z"
+
+    def test_zero_sum_preserved_across_matches(self):
+        ratings: dict = {}
+        apply_match(ratings, "a", "b", "t")
+        apply_match(ratings, "b", "a", "t")
+        # Rating total preserved (start = 2 * INITIAL_RATING)
+        total = ratings["a"]["rating"] + ratings["b"]["rating"]
+        assert total == pytest.approx(2 * INITIAL_RATING)
+
+    def test_constants_match_classical_chess(self):
+        # Sanity: K=32 is the classic value, drift if anyone changes it
+        assert K_FACTOR == 32.0
+        assert INITIAL_RATING == 1500.0

--- a/tests/test_rankings_api.py
+++ b/tests/test_rankings_api.py
@@ -1,0 +1,76 @@
+"""Smoke tests for /api/rankings and /api/rankings/history endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import rankings_storage
+from backend.main import app
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Each test gets a fresh data dir."""
+    monkeypatch.setattr(rankings_storage, "DATA_BASE_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _record_round(label_to_model, voter_rankings):
+    results = [
+        {"model": v, "parsed_ranking": labels} for v, labels in voter_rankings
+    ]
+    return rankings_storage.record_stage2_matches(
+        results, label_to_model, conversation_id="test-conv", user_id=None
+    )
+
+
+class TestRankingsEndpoint:
+    def test_empty_state_returns_empty_leaderboard(self, isolated_data_dir, client):
+        response = client.get("/api/rankings")
+        assert response.status_code == 200
+        assert response.json() == {"leaderboard": []}
+
+    def test_returns_sorted_leaderboard_after_round(self, isolated_data_dir, client):
+        labels = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
+        _record_round(labels, [
+            ("alpha", ["Response A", "Response B", "Response C"]),
+            ("beta", ["Response A", "Response B", "Response C"]),
+        ])
+        response = client.get("/api/rankings")
+        assert response.status_code == 200
+        board = response.json()["leaderboard"]
+        assert len(board) == 3
+        # Alpha has 2 wins, beta has 1 win, gamma has 0 → alpha > beta > gamma
+        assert [row["model"] for row in board] == ["alpha", "beta", "gamma"]
+        assert [row["rank"] for row in board] == [1, 2, 3]
+        # Each row has the documented shape
+        assert set(board[0]) == {"model", "rating", "games", "last_updated", "rank"}
+
+
+class TestRankingsHistoryEndpoint:
+    def test_empty_state_returns_empty_history(self, isolated_data_dir, client):
+        response = client.get("/api/rankings/history")
+        assert response.status_code == 200
+        assert response.json() == {"history": {}}
+
+    def test_returns_per_model_series(self, isolated_data_dir, client):
+        labels = {"Response A": "alpha", "Response B": "beta"}
+        _record_round(labels, [("alpha", ["Response A", "Response B"])])
+        response = client.get("/api/rankings/history")
+        assert response.status_code == 200
+        history = response.json()["history"]
+        assert set(history.keys()) == {"alpha", "beta"}
+        # One pair recorded → one snapshot per model
+        assert len(history["alpha"]) == 1
+        assert {"ts", "rating", "games"} <= set(history["alpha"][0])
+
+    def test_model_filter_narrows_response(self, isolated_data_dir, client):
+        labels = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
+        _record_round(labels, [("alpha", ["Response A", "Response B", "Response C"])])
+        response = client.get("/api/rankings/history", params={"model": "alpha"})
+        assert response.status_code == 200
+        assert set(response.json()["history"].keys()) == {"alpha"}

--- a/tests/test_rankings_storage.py
+++ b/tests/test_rankings_storage.py
@@ -1,0 +1,176 @@
+"""Tests for rankings persistence (matches.jsonl + ratings.json)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend import rankings_storage
+from backend.elo import INITIAL_RATING
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Point storage at a fresh temp dir for each test."""
+    monkeypatch.setattr(rankings_storage, "DATA_BASE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _stage2_round(label_to_model: dict[str, str], voter_rankings: list[tuple[str, list[str]]]):
+    """Helper: build a stage2_results-shaped payload from (voter, [labels]) pairs."""
+    return [
+        {"model": voter, "parsed_ranking": labels}
+        for voter, labels in voter_rankings
+    ]
+
+
+class TestRecordStage2Matches:
+    def test_writes_jsonl_and_ratings(self, isolated_data_dir):
+        label_to_model = {
+            "Response A": "model-a",
+            "Response B": "model-b",
+            "Response C": "model-c",
+        }
+        # Three voters, all rank A > B > C
+        results = _stage2_round(
+            label_to_model,
+            [
+                ("model-a", ["Response A", "Response B", "Response C"]),
+                ("model-b", ["Response A", "Response B", "Response C"]),
+                ("model-c", ["Response A", "Response B", "Response C"]),
+            ],
+        )
+        count = rankings_storage.record_stage2_matches(
+            results, label_to_model, conversation_id="conv-1", user_id=None
+        )
+        # 3 voters × C(3,2) = 9 pairwise comparisons
+        assert count == 9
+
+        matches_file = Path(isolated_data_dir) / "rankings" / "matches.jsonl"
+        assert matches_file.exists()
+        lines = matches_file.read_text().strip().splitlines()
+        assert len(lines) == 9
+
+        # Every line must be valid JSON with the expected fields
+        for line in lines:
+            rec = json.loads(line)
+            assert set(rec) == {"ts", "conversation_id", "voter", "winner", "loser"}
+            assert rec["conversation_id"] == "conv-1"
+
+    def test_ratings_reflect_unanimous_winner(self, isolated_data_dir):
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        results = _stage2_round(
+            label_to_model,
+            [
+                ("alpha", ["Response A", "Response B"]),
+                ("beta", ["Response A", "Response B"]),
+            ],
+        )
+        rankings_storage.record_stage2_matches(results, label_to_model, "c", None)
+        state = rankings_storage.load_ratings()
+        assert state["ratings"]["alpha"]["rating"] > INITIAL_RATING
+        assert state["ratings"]["beta"]["rating"] < INITIAL_RATING
+        assert state["ratings"]["alpha"]["games"] == 2
+        assert state["ratings"]["beta"]["games"] == 2
+
+    def test_empty_rankings_records_nothing(self, isolated_data_dir):
+        # Voters present but no parsed_rankings (e.g., parser failed)
+        results = [{"model": "alpha", "parsed_ranking": []}]
+        count = rankings_storage.record_stage2_matches(results, {}, "c", None)
+        assert count == 0
+        # No files created
+        assert not (Path(isolated_data_dir) / "rankings" / "matches.jsonl").exists()
+
+    def test_per_user_isolation(self, isolated_data_dir):
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        results = _stage2_round(
+            label_to_model, [("alpha", ["Response A", "Response B"])]
+        )
+        rankings_storage.record_stage2_matches(results, label_to_model, "c", user_id="alice")
+        rankings_storage.record_stage2_matches(results, label_to_model, "c", user_id="bob")
+
+        alice_state = rankings_storage.load_ratings("alice")
+        bob_state = rankings_storage.load_ratings("bob")
+        # Each user has independent ratings — same input, same outcome
+        assert alice_state["ratings"]["alpha"]["games"] == 1
+        assert bob_state["ratings"]["alpha"]["games"] == 1
+        # Anonymous user has no data
+        assert rankings_storage.load_ratings(None) == {"version": 1, "ratings": {}}
+
+    def test_replay_matches_live_updates(self, isolated_data_dir):
+        """Source-of-truth invariant: replaying matches.jsonl yields the same ratings."""
+        label_to_model = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
+        # Two rounds with mixed outcomes
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [
+                ("alpha", ["Response A", "Response B", "Response C"]),
+                ("beta", ["Response B", "Response A", "Response C"]),
+            ]),
+            label_to_model, "c1", None,
+        )
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [
+                ("gamma", ["Response C", "Response A", "Response B"]),
+            ]),
+            label_to_model, "c2", None,
+        )
+
+        live = rankings_storage.load_ratings()["ratings"]
+        # Replay from scratch
+        history = rankings_storage.replay_history()
+        # Final entry per model should match the live rating
+        for model, snapshots in history.items():
+            final_rating = snapshots[-1]["rating"]
+            assert final_rating == pytest.approx(round(live[model]["rating"], 1))
+
+
+class TestGetLeaderboard:
+    def test_empty_when_no_data(self, isolated_data_dir):
+        assert rankings_storage.get_leaderboard() == []
+
+    def test_sorted_descending_with_ranks(self, isolated_data_dir):
+        label_to_model = {"Response A": "winner", "Response B": "loser"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [("winner", ["Response A", "Response B"])]),
+            label_to_model, "c", None,
+        )
+        board = rankings_storage.get_leaderboard()
+        assert len(board) == 2
+        assert board[0]["model"] == "winner"
+        assert board[0]["rank"] == 1
+        assert board[1]["model"] == "loser"
+        assert board[1]["rank"] == 2
+        assert board[0]["rating"] > board[1]["rating"]
+
+
+class TestReplayHistory:
+    def test_returns_empty_when_no_log(self, isolated_data_dir):
+        assert rankings_storage.replay_history() == {}
+
+    def test_filter_returns_only_target_model(self, isolated_data_dir):
+        label_to_model = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [
+                ("alpha", ["Response A", "Response B", "Response C"]),
+            ]),
+            label_to_model, "c", None,
+        )
+        history = rankings_storage.replay_history(model_filter="alpha")
+        assert set(history.keys()) == {"alpha"}
+        # Alpha appears in 2 of the 3 pairs (A>B, A>C)
+        assert len(history["alpha"]) == 2
+
+    def test_skips_malformed_lines(self, isolated_data_dir):
+        # Manually plant a bad line in the JSONL
+        rdir = Path(isolated_data_dir) / "rankings"
+        rdir.mkdir(parents=True)
+        path = rdir / "matches.jsonl"
+        path.write_text(
+            'not-json\n'
+            '{"ts": "t", "winner": "a", "loser": "b"}\n'
+            '{"missing": "fields"}\n'
+        )
+        history = rankings_storage.replay_history()
+        # Only the valid record contributed
+        assert set(history.keys()) == {"a", "b"}
+        assert len(history["a"]) == 1

--- a/tests/test_rankings_storage.py
+++ b/tests/test_rankings_storage.py
@@ -16,8 +16,12 @@ def isolated_data_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _stage2_round(label_to_model: dict[str, str], voter_rankings: list[tuple[str, list[str]]]):
-    """Helper: build a stage2_results-shaped payload from (voter, [labels]) pairs."""
+def _stage2_round(voter_rankings: list[tuple[str, list[str]]]):
+    """Helper: build a stage2_results-shaped payload from (voter, [labels]) pairs.
+
+    Tests pass ``label_to_model`` separately to ``record_stage2_matches``;
+    the helper just needs the per-voter rankings.
+    """
     return [
         {"model": voter, "parsed_ranking": labels}
         for voter, labels in voter_rankings
@@ -32,14 +36,11 @@ class TestRecordStage2Matches:
             "Response C": "model-c",
         }
         # Three voters, all rank A > B > C
-        results = _stage2_round(
-            label_to_model,
-            [
-                ("model-a", ["Response A", "Response B", "Response C"]),
-                ("model-b", ["Response A", "Response B", "Response C"]),
-                ("model-c", ["Response A", "Response B", "Response C"]),
-            ],
-        )
+        results = _stage2_round([
+            ("model-a", ["Response A", "Response B", "Response C"]),
+            ("model-b", ["Response A", "Response B", "Response C"]),
+            ("model-c", ["Response A", "Response B", "Response C"]),
+        ])
         count = rankings_storage.record_stage2_matches(
             results, label_to_model, conversation_id="conv-1", user_id=None
         )
@@ -59,13 +60,10 @@ class TestRecordStage2Matches:
 
     def test_ratings_reflect_unanimous_winner(self, isolated_data_dir):
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
-        results = _stage2_round(
-            label_to_model,
-            [
-                ("alpha", ["Response A", "Response B"]),
-                ("beta", ["Response A", "Response B"]),
-            ],
-        )
+        results = _stage2_round([
+            ("alpha", ["Response A", "Response B"]),
+            ("beta", ["Response A", "Response B"]),
+        ])
         rankings_storage.record_stage2_matches(results, label_to_model, "c", None)
         state = rankings_storage.load_ratings()
         assert state["ratings"]["alpha"]["rating"] > INITIAL_RATING
@@ -83,9 +81,7 @@ class TestRecordStage2Matches:
 
     def test_per_user_isolation(self, isolated_data_dir):
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
-        results = _stage2_round(
-            label_to_model, [("alpha", ["Response A", "Response B"])]
-        )
+        results = _stage2_round([("alpha", ["Response A", "Response B"])])
         rankings_storage.record_stage2_matches(results, label_to_model, "c", user_id="alice")
         rankings_storage.record_stage2_matches(results, label_to_model, "c", user_id="bob")
 
@@ -102,14 +98,14 @@ class TestRecordStage2Matches:
         label_to_model = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
         # Two rounds with mixed outcomes
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [
+            _stage2_round([
                 ("alpha", ["Response A", "Response B", "Response C"]),
                 ("beta", ["Response B", "Response A", "Response C"]),
             ]),
             label_to_model, "c1", None,
         )
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [
+            _stage2_round([
                 ("gamma", ["Response C", "Response A", "Response B"]),
             ]),
             label_to_model, "c2", None,
@@ -118,10 +114,15 @@ class TestRecordStage2Matches:
         live = rankings_storage.load_ratings()["ratings"]
         # Replay from scratch
         history = rankings_storage.replay_history()
-        # Final entry per model should match the live rating
+        # Final entry per model should match the live rating.
+        # `replay_history` rounds each snapshot to 1dp while internal state
+        # accumulates at full precision; `load_ratings` returns full
+        # precision. Compare both at 1dp with an explicit tolerance to
+        # absorb any per-step rounding drift over many matches.
         for model, snapshots in history.items():
-            final_rating = snapshots[-1]["rating"]
-            assert final_rating == pytest.approx(round(live[model]["rating"], 1))
+            final_replay = snapshots[-1]["rating"]
+            final_live = round(live[model]["rating"], 1)
+            assert final_replay == pytest.approx(final_live, abs=0.1)
 
 
 class TestGetLeaderboard:
@@ -131,7 +132,7 @@ class TestGetLeaderboard:
     def test_sorted_descending_with_ranks(self, isolated_data_dir):
         label_to_model = {"Response A": "winner", "Response B": "loser"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [("winner", ["Response A", "Response B"])]),
+            _stage2_round([("winner", ["Response A", "Response B"])]),
             label_to_model, "c", None,
         )
         board = rankings_storage.get_leaderboard()
@@ -148,7 +149,7 @@ class TestLoadRatings:
         """If ratings.json is deleted but matches.jsonl exists, leaderboard rebuilds."""
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            _stage2_round([("alpha", ["Response A", "Response B"])]),
             label_to_model, "c", None,
         )
         ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
@@ -160,7 +161,7 @@ class TestLoadRatings:
     def test_rebuilds_from_log_when_ratings_json_corrupt(self, isolated_data_dir):
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            _stage2_round([("alpha", ["Response A", "Response B"])]),
             label_to_model, "c", None,
         )
         ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
@@ -175,7 +176,7 @@ class TestLoadRatings:
         # downstream when callers try to iterate `.items()`.
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            _stage2_round([("alpha", ["Response A", "Response B"])]),
             label_to_model, "c", None,
         )
         ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
@@ -191,7 +192,7 @@ class TestLoadRatings:
         # match log has a record that ratings.json doesn't reflect.
         label_to_model = {"Response A": "alpha", "Response B": "beta"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            _stage2_round([("alpha", ["Response A", "Response B"])]),
             label_to_model, "c1", None,
         )
         # Manually append a second match to JSONL but DO NOT update ratings.json
@@ -231,7 +232,7 @@ class TestReplayHistory:
     def test_filter_returns_only_target_model(self, isolated_data_dir):
         label_to_model = {"Response A": "alpha", "Response B": "beta", "Response C": "gamma"}
         rankings_storage.record_stage2_matches(
-            _stage2_round(label_to_model, [
+            _stage2_round([
                 ("alpha", ["Response A", "Response B", "Response C"]),
             ]),
             label_to_model, "c", None,

--- a/tests/test_rankings_storage.py
+++ b/tests/test_rankings_storage.py
@@ -143,6 +143,52 @@ class TestGetLeaderboard:
         assert board[0]["rating"] > board[1]["rating"]
 
 
+class TestLoadRatings:
+    def test_rebuilds_from_log_when_ratings_json_missing(self, isolated_data_dir):
+        """If ratings.json is deleted but matches.jsonl exists, leaderboard rebuilds."""
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            label_to_model, "c", None,
+        )
+        ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
+        ratings_file.unlink()
+        state = rankings_storage.load_ratings()
+        assert state["ratings"]["alpha"]["games"] == 1
+        assert state["ratings"]["alpha"]["rating"] > 1500
+
+    def test_rebuilds_from_log_when_ratings_json_corrupt(self, isolated_data_dir):
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            label_to_model, "c", None,
+        )
+        ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
+        ratings_file.write_text("not valid json {{{")
+        state = rankings_storage.load_ratings()
+        assert "alpha" in state["ratings"]
+        assert state["ratings"]["alpha"]["games"] == 1
+
+
+class TestUserIdValidation:
+    def test_rejects_path_separator(self, isolated_data_dir):
+        with pytest.raises(ValueError, match="Unsafe user_id"):
+            rankings_storage.load_ratings(user_id="../etc/passwd")
+
+    def test_rejects_dotdot(self, isolated_data_dir):
+        with pytest.raises(ValueError, match="Unsafe user_id"):
+            rankings_storage.load_ratings(user_id="..")
+
+    def test_rejects_empty_string(self, isolated_data_dir):
+        with pytest.raises(ValueError, match="Unsafe user_id"):
+            rankings_storage.load_ratings(user_id="")
+
+    def test_accepts_normal_usernames(self, isolated_data_dir):
+        rankings_storage.load_ratings(user_id="alice")
+        rankings_storage.load_ratings(user_id="user_42")
+        rankings_storage.load_ratings(user_id="alice@example.com")
+
+
 class TestReplayHistory:
     def test_returns_empty_when_no_log(self, isolated_data_dir):
         assert rankings_storage.replay_history() == {}

--- a/tests/test_rankings_storage.py
+++ b/tests/test_rankings_storage.py
@@ -169,6 +169,41 @@ class TestLoadRatings:
         assert "alpha" in state["ratings"]
         assert state["ratings"]["alpha"]["games"] == 1
 
+    def test_rebuilds_when_ratings_json_has_invalid_shape(self, isolated_data_dir):
+        # Parseable JSON, wrong shape (ratings should be a dict, not a list).
+        # Without schema validation this passes load_ratings and explodes
+        # downstream when callers try to iterate `.items()`.
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            label_to_model, "c", None,
+        )
+        ratings_file = Path(isolated_data_dir) / "rankings" / "ratings.json"
+        ratings_file.write_text('{"version": 1, "ratings": []}')  # valid JSON, invalid shape
+        state = rankings_storage.load_ratings()
+        # Should have rebuilt from the log
+        assert isinstance(state["ratings"], dict)
+        assert "alpha" in state["ratings"]
+        assert state["ratings"]["alpha"]["games"] == 1
+
+    def test_rebuilds_when_ratings_json_is_stale(self, isolated_data_dir):
+        # Simulate crash after JSONL append but before ratings.json write:
+        # match log has a record that ratings.json doesn't reflect.
+        label_to_model = {"Response A": "alpha", "Response B": "beta"}
+        rankings_storage.record_stage2_matches(
+            _stage2_round(label_to_model, [("alpha", ["Response A", "Response B"])]),
+            label_to_model, "c1", None,
+        )
+        # Manually append a second match to JSONL but DO NOT update ratings.json
+        matches_file = Path(isolated_data_dir) / "rankings" / "matches.jsonl"
+        with open(matches_file, "a") as f:
+            f.write('{"ts": "2026-04-26T00:00:00Z", "conversation_id": "c2", '
+                    '"voter": "alpha", "winner": "alpha", "loser": "beta"}\n')
+        state = rankings_storage.load_ratings()
+        # Stale detection should have triggered a rebuild including the second match
+        assert state["ratings"]["alpha"]["games"] == 2
+        assert state["ratings"]["beta"]["games"] == 2
+
 
 class TestUserIdValidation:
     def test_rejects_path_separator(self, isolated_data_dir):


### PR DESCRIPTION
## Summary

A new **Standings** view that captures Stage 2 peer rankings as ELO ratings persisted across all conversations, surfaced as a sortable leaderboard and per-model trend chart.

The data was already there: \`stage2_collect_rankings()\` returns per-voter parsed rankings and they evaporated after every conversation. This PR taps that signal at \`council_stream.py\` and writes pairwise comparisons to a JSONL match log + JSON ratings file (mirroring the existing \`pending.json\` fcntl/atomic-write pattern — no new dependencies, no SQLite).

## Architecture

\`\`\`
Stage 2 results → record_stage2_matches() → matches.jsonl + ratings.json
                                                ↓
GET /api/rankings           → leaderboard
GET /api/rankings/history   → per-model time series (replayed from log)
                                                ↓
Standings.jsx (table + recharts trend)
\`\`\`

- **Scoring:** classic ELO, K=32, initial 1500. Each Stage 2 round = V × C(N,2) pairwise updates (4 voters × 6 pairs = 24 updates).
- **Per-user isolation** mirrors existing conversation storage via \`user_id\` parameter.
- **Source-of-truth:** matches.jsonl is authoritative — ratings.json can be rebuilt by replaying the log. Tested via the \`replay_matches_live_updates\` invariant.
- **Failure isolation:** the tap point is wrapped in try/except so storage errors never break the SSE stream.

## Out of scope (intentional)

- Backfilling historical conversations (one-shot script later if useful)
- Arena Mode scoring (debate rounds aren't ranked the same way)
- Confidence intervals / Glicko-2 (overkill until thousands of rounds)
- Voter-trust weighting (circular)

## Test plan

- [x] \`tests/test_elo.py\` — 19 tests for pure ELO math (symmetry, zero-sum, K-factor scaling)
- [x] \`tests/test_rankings_storage.py\` — 10 tests including the live-vs-replay invariant
- [x] \`tests/test_rankings_api.py\` — 5 TestClient smoke tests for both endpoints
- [x] Full backend suite: **225 passing**, 0 regressions
- [x] Frontend builds clean (\`npm run build\`)
- [x] Test isolation hardened (\`tests/conftest.py\` redirects \`LLMCOUNCIL_DATA_DIR\` to a session tempdir, preventing test data from leaking to real \`./data/\`)
- [ ] Manual visual smoke: navigate to /standings, run a council round, confirm leaderboard + trend chart populate
- [ ] Auth-mode isolation: \`LLMCOUNCIL_AUTH_ENABLED=true\` with two simulated users → independent leaderboards

Plan doc: \`docs/plans/2026-04-25-council-standings.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Council Standings view with sortable ELO leaderboard, per-model trend chart, sidebar toggle, and view switching; frontend hooks and API methods to fetch standings/history.

* **Bug Fixes / Reliability**
  * Stage 2 match persistence is now best-effort and failure-tolerant so streaming isn't interrupted.

* **Documentation**
  * Added design spec for persistent standings, scoring, storage, and verification checklist.

* **Tests**
  * Comprehensive tests for ELO math, storage persistence/replay, and rankings API endpoints.

* **Chores**
  * Added charting dependency (recharts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->