### PR TITLE
fix(council): skip Stage 1 failures when collecting Stage 2 rankings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stage 2 ranking no longer includes models that failed in Stage 1, eliminating duplicate
+  404s, redundant OpenRouter calls, and duplicated Sentry events when a council model's
+  endpoint is deprecated or unavailable.
+
 ## [0.7.0] - 2024-12-21
 
 ### Added

--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -637,9 +637,11 @@ async def retry_rankings_pipeline(
         )
 
         # Re-run Stage 2
+        # Only successful Stage 1 models should rank — see council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
+        ranking_models = [r["model"] for r in stage1_results]
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
-            user_query, stage1_results, council_models
+            user_query, stage1_results, ranking_models
         )
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
         _persist_stage2_matches_safely(
@@ -794,9 +796,11 @@ async def retry_all_pipeline(
             return
 
         # Stage 2: Rankings
+        # Only successful Stage 1 models should rank — see council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
+        ranking_models = [r["model"] for r in stage1_results]
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
-            user_query, stage1_results, council_models
+            user_query, stage1_results, ranking_models
         )
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
         _persist_stage2_matches_safely(

--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -25,6 +25,16 @@ from .rankings_storage import record_stage2_matches
 logger = logging.getLogger(__name__)
 
 
+def _derive_ranking_models(stage1_results: list[dict[str, Any]]) -> list[str]:
+    """Return the list of model IDs that produced Stage 1 outputs.
+
+    Stage 2 ranks only models that successfully responded in Stage 1 — see
+    council-wuj. Centralizing this derivation prevents drift across the main
+    pipeline and the two retry pipelines.
+    """
+    return [r["model"] for r in stage1_results]
+
+
 def _persist_stage2_matches_safely(
     stage2_results: list[dict[str, Any]],
     label_to_model: dict[str, str],
@@ -355,7 +365,7 @@ async def run_council_pipeline(
         # generate duplicate errors — see issue council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
         stage2_start = time.monotonic()
-        ranking_models = [r["model"] for r in stage1_results]
+        ranking_models = _derive_ranking_models(stage1_results)
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
             input.content, stage1_results, ranking_models
         )
@@ -639,7 +649,7 @@ async def retry_rankings_pipeline(
         # Re-run Stage 2
         # Only successful Stage 1 models should rank — see council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
-        ranking_models = [r["model"] for r in stage1_results]
+        ranking_models = _derive_ranking_models(stage1_results)
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
             user_query, stage1_results, ranking_models
         )
@@ -798,7 +808,7 @@ async def retry_all_pipeline(
         # Stage 2: Rankings
         # Only successful Stage 1 models should rank — see council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
-        ranking_models = [r["model"] for r in stage1_results]
+        ranking_models = _derive_ranking_models(stage1_results)
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
             user_query, stage1_results, ranking_models
         )

--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -368,7 +368,7 @@ async def run_council_pipeline(
         stage2_duration = time.monotonic() - stage2_start
         logger.info(
             "Stage 2 complete. ConversationId: %s, Rankings: %d/%d, Errors: %d, Duration: %.2fs",
-            input.conversation_id, len(stage2_results), len(input.council_models),
+            input.conversation_id, len(stage2_results), len(ranking_models),
             len(stage2_errors), stage2_duration,
         )
         metadata = {

--- a/backend/council_stream.py
+++ b/backend/council_stream.py
@@ -350,10 +350,14 @@ async def run_council_pipeline(
             )
 
         # --- Stage 2: Collect rankings ---
+        # Only models that produced a Stage 1 response should be asked to rank;
+        # otherwise failed models (e.g., deprecated endpoints) get re-queried and
+        # generate duplicate errors — see issue council-wuj.
         yield {"type": "round_start", "data": {"round_type": "rankings"}}
         stage2_start = time.monotonic()
+        ranking_models = [r["model"] for r in stage1_results]
         stage2_results, label_to_model, stage2_errors = await stage2_collect_rankings(
-            input.content, stage1_results, input.council_models
+            input.content, stage1_results, ranking_models
         )
         aggregate_rankings = calculate_aggregate_rankings(
             stage2_results, label_to_model

--- a/tests/test_council_stream.py
+++ b/tests/test_council_stream.py
@@ -225,6 +225,60 @@ class TestCouncilPipelineResume:
         mock_s1.assert_not_called()
 
 
+class TestCouncilPipelineStageWiring:
+    """Pipeline wires successful Stage 1 models forward — failed models do not rank."""
+
+    @pytest.mark.asyncio
+    async def test_stage2_receives_only_models_that_succeeded_in_stage1(self):
+        """Stage 2 must rank using only the models that produced Stage 1 responses.
+
+        Regression test for council-wuj: a deprecated model (e.g. google/gemini-3-pro-preview)
+        that 404s in Stage 1 was still being asked to rank in Stage 2, generating duplicate
+        Sentry events and wasted API calls per request.
+        """
+        inp = make_input(council_models=["model-a", "model-b", "dead-model"])
+        storage = make_mock_storage()
+
+        # Stage 1 simulates dead-model failing — it does not appear in stage1_results.
+        surviving_results = [
+            {"model": "model-a", "response": "Answer A", "metrics": {}},
+            {"model": "model-b", "response": "Answer B", "metrics": {}},
+        ]
+
+        with (
+            patch("backend.council_stream.stage1_collect_responses", new_callable=AsyncMock) as mock_s1,
+            patch("backend.council_stream.stage2_collect_rankings", new_callable=AsyncMock) as mock_s2,
+            patch("backend.council_stream.stage3_synthesize_final", new_callable=AsyncMock) as mock_s3,
+            patch("backend.council_stream.generate_conversation_title", new_callable=AsyncMock),
+            patch("backend.council_stream.calculate_aggregate_rankings") as mock_agg,
+            patch("backend.council_stream.aggregate_metrics") as mock_metrics,
+            patch("backend.council_stream.convert_to_unified_result") as mock_convert,
+            patch("backend.council_stream.process_attachments") as mock_attach,
+        ):
+            async def fake_stage1(content, context, models, **kwargs):
+                cb = kwargs.get("on_model_response")
+                if cb:
+                    for r in surviving_results:
+                        await cb(r["model"], r)
+                return surviving_results
+
+            mock_s1.side_effect = fake_stage1
+            mock_s2.return_value = (STAGE2_RESULTS, LABEL_TO_MODEL, [])
+            mock_s3.return_value = STAGE3_RESULT
+            mock_agg.return_value = []
+            mock_metrics.return_value = {}
+            mock_convert.return_value = MagicMock()
+            mock_attach.return_value = ("", [])
+
+            await collect_events(run_council_pipeline(inp, storage=storage))
+
+        mock_s2.assert_called_once()
+        passed_models = mock_s2.call_args.args[2]
+        assert passed_models == ["model-a", "model-b"], (
+            f"Stage 2 received {passed_models!r}; dead-model must not be asked to rank"
+        )
+
+
 class TestCouncilPipelineErrors:
     """Error handling behavior."""
 


### PR DESCRIPTION
## Summary

- Stage 2 was being asked to rank using the original `input.council_models` list, even when some models had failed in Stage 1. The dead model would 404 a second time during ranking, generating a duplicate Sentry event and an avoidable OpenRouter API call per request.
- Fix derives the ranker list from `stage1_results` (which already excludes failures).
- Sentry surfaced this via [LLM-COUNCIL-8](https://sentry.io/organizations/cameronsjo/issues/7366915323/) where `google/gemini-3-pro-preview` 404'd twice per request — once in Stage 1, once in Stage 2 ranking.

Closes `council-wuj`.

## Test plan

- [x] New regression test `TestCouncilPipelineStageWiring::test_stage2_receives_only_models_that_succeeded_in_stage1` — input has 3 council models, Stage 1 returns 2 (one "dead"), assert `stage2_collect_rankings` receives only the 2 surviving models
- [x] Test fails before fix, passes after
- [x] Full suite: 236 passed
- [x] Lint: no new findings in touched files (3 pre-existing F401s unchanged)

## Follow-ups (separately tracked in beads)

- `council-tvq` — drop per-model HTTP error logs from `error` to `warning` to cut Sentry noise for gracefully-handled failures
- `council-rkt` — streaming-mode error path doesn't read response body before extracting the OpenRouter error message, so it logs bare `"HTTP 404"` instead of `"No endpoints found for ..."`
- `council-lfv` — replace stale `gemini-3-pro-preview` defaults in `backend/config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stage 2 ranking now only considers models that produced successful Stage 1 responses, preventing cascading duplicate external calls and redundant error/Sentry reporting when downstream endpoints fail.

* **Tests**
  * Added an async test that verifies Stage 2 receives only successful Stage 1 model IDs, ensuring failed or dead models are excluded from downstream ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->