### PR TITLE
fix(openrouter): downgrade per-model error logs to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Per-model HTTP and timeout failures now log at `warning` instead of `error`. When the
+  council pipeline gracefully degrades (some models fail, others succeed), individual
+  model failures no longer escalate to Sentry. Auth (401), billing (402), and unexpected
+  exceptions still log at `error`. The aggregate "all models failed" path remains the
+  Sentry escalation point.
+
 ## [0.7.0] - 2024-12-21
 
 ### Added

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -211,7 +211,10 @@ async def query_model(
                         model, error_msg,
                     )
                 else:
-                    logger.error(
+                    # Per-model HTTP error (e.g., 404 for a deprecated model). The pipeline
+                    # gracefully degrades, so this is warning-level noise rather than a
+                    # Sentry-grade error. The aggregate "all models failed" path escalates.
+                    logger.warning(
                         "HTTP error querying %s (status %d). Detail: %s",
                         model, status, error_msg,
                     )
@@ -223,7 +226,8 @@ async def query_model(
                 return ModelError(model, status, _classify_error(status), error_msg)
 
             except httpx.TimeoutException as e:
-                logger.error("Timeout querying %s after %.0fs: %s", model, timeout, e)
+                # Per-model timeout — pipeline degrades; aggregate failure escalates.
+                logger.warning("Timeout querying %s after %.0fs: %s", model, timeout, e)
                 if is_telemetry_enabled():
                     span.record_exception(e)
                     from opentelemetry.trace import Status, StatusCode
@@ -475,7 +479,8 @@ async def query_model_streaming(
                         model, error_msg,
                     )
                 else:
-                    logger.error(
+                    # Per-model HTTP error — gracefully handled; see parallel-path note.
+                    logger.warning(
                         "HTTP error streaming %s (status %d). Detail: %s",
                         model, status, error_msg,
                     )
@@ -496,7 +501,8 @@ async def query_model_streaming(
                     await asyncio.sleep(delay)
                     continue
 
-                logger.error("Timeout streaming %s after %d attempts (%.0fs each): %s", model, MAX_RETRIES, timeout, e)
+                # Per-model timeout post-retries — gracefully handled.
+                logger.warning("Timeout streaming %s after %d attempts (%.0fs each): %s", model, MAX_RETRIES, timeout, e)
                 if is_telemetry_enabled():
                     span.record_exception(e)
                     from opentelemetry.trace import Status, StatusCode

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -1,6 +1,7 @@
 """Tests for query_model: shared client, retry, differentiated errors."""
 
 import asyncio
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -232,6 +233,43 @@ class TestQueryModel:
         assert "something broke" in result.message
 
 
+_OPENROUTER_LOGGER = "backend.openrouter"
+
+
+def _records(caplog, level: str) -> list:
+    """Return caplog records emitted by the openrouter logger at ``level``."""
+    return [
+        r for r in caplog.records
+        if r.levelname == level and r.name == _OPENROUTER_LOGGER
+    ]
+
+
+def _assert_log_severity(
+    caplog,
+    *,
+    expect_warning: bool,
+    expect_error: bool,
+    context: str,
+) -> None:
+    """Assert openrouter log records match the expected severity contract.
+
+    ``expect_warning`` requires at least one WARNING record; ``expect_error``
+    flips between requiring at least one ERROR record (True) or none (False).
+    Used by both TestQueryModelLogLevels and TestQueryModelStreamingLogLevels.
+    """
+    warning_records = _records(caplog, "WARNING")
+    error_records = _records(caplog, "ERROR")
+    if expect_warning:
+        assert warning_records, f"{context} should emit a WARNING breadcrumb"
+    if expect_error:
+        assert error_records, f"{context} should log at ERROR for Sentry visibility"
+    else:
+        assert error_records == [], (
+            f"{context} must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+
 class TestQueryModelLogLevels:
     """Per-model failures that the pipeline gracefully handles must not log at ERROR.
 
@@ -249,137 +287,72 @@ class TestQueryModelLogLevels:
         )
         return httpx.HTTPStatusError("err", request=resp.request, response=resp)
 
+    async def _run_with_post_side_effect(self, side_effect, caplog, model="model-a"):
+        with (
+            patch.object(get_shared_client(), "post", AsyncMock(side_effect=side_effect)),
+            caplog.at_level("DEBUG", logger=_OPENROUTER_LOGGER),
+        ):
+            return await query_model(model, [{"role": "user", "content": "hi"}])
+
     @pytest.mark.asyncio
     async def test_404_logs_at_warning_not_error(self, caplog):
-        """A 404 on a single model (e.g., deprecated endpoint) is gracefully handled."""
-        mock_post = AsyncMock(side_effect=self._make_status_error(404))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("dead-model", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            self._make_status_error(404), caplog, model="dead-model",
+        )
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Per-model 404 should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Per-model 404 must not log at ERROR (Sentry noise); got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Per-model 404",
         )
 
     @pytest.mark.asyncio
     async def test_500_logs_at_warning_not_error(self, caplog):
-        """A non-retryable 5xx on a single model is gracefully handled."""
-        mock_post = AsyncMock(side_effect=self._make_status_error(500))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            self._make_status_error(500), caplog,
+        )
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Per-model 500 should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Per-model 500 must not log at ERROR; got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Per-model 500",
         )
 
     @pytest.mark.asyncio
     async def test_401_still_logs_at_error(self, caplog):
-        """Auth failures affect every request and warrant Sentry escalation."""
-        mock_post = AsyncMock(side_effect=self._make_status_error(401))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            self._make_status_error(401), caplog,
+        )
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "401 must still log at ERROR for Sentry visibility"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="401 auth failure",
+        )
 
     @pytest.mark.asyncio
     async def test_402_still_logs_at_error(self, caplog):
-        """Billing failures affect every request and warrant Sentry escalation."""
-        mock_post = AsyncMock(side_effect=self._make_status_error(402))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            self._make_status_error(402), caplog,
+        )
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "402 must still log at ERROR for Sentry visibility"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="402 billing failure",
+        )
 
     @pytest.mark.asyncio
     async def test_timeout_logs_at_warning(self, caplog):
-        """Per-model timeout is gracefully handled, not a Sentry-grade error."""
-        mock_post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            httpx.TimeoutException("timed out"), caplog,
+        )
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Per-model timeout should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Per-model timeout must not log at ERROR; got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Per-model timeout",
         )
 
     @pytest.mark.asyncio
     async def test_unexpected_exception_still_logs_at_error(self, caplog):
-        """Unknown/unexpected exceptions deserve full Sentry visibility."""
-        mock_post = AsyncMock(side_effect=RuntimeError("something broke"))
-
-        with (
-            patch.object(get_shared_client(), "post", mock_post),
-            caplog.at_level("DEBUG", logger="backend.openrouter"),
-        ):
-            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
-
+        result = await self._run_with_post_side_effect(
+            RuntimeError("something broke"), caplog,
+        )
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "Unexpected exceptions must still log at ERROR"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="Unexpected exception",
+        )
 
 
 class TestQueryModelStreamingLogLevels:
@@ -406,159 +379,83 @@ class TestQueryModelStreamingLogLevels:
 
         return teardown
 
-    @pytest.mark.asyncio
-    async def test_streaming_404_logs_at_warning_not_error(self, caplog):
-        """Streaming-mode 404 (deprecated model) is gracefully handled."""
-        teardown = self._install_streaming_handler(
-            lambda req: httpx.Response(404, json={"error": {"message": "no endpoints"}}),
-        )
+    async def _run_streaming(self, handler, caplog, model="model-a", *, retry_zero=False):
+        teardown = self._install_streaming_handler(handler)
         try:
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model_streaming(
-                    "dead-model", [{"role": "user", "content": "hi"}],
+            ctx_managers = [caplog.at_level("DEBUG", logger=_OPENROUTER_LOGGER)]
+            if retry_zero:
+                ctx_managers.append(patch("backend.openrouter.RETRY_BASE_DELAY", 0))
+            with ExitStack() as stack:
+                for cm in ctx_managers:
+                    stack.enter_context(cm)
+                return await query_model_streaming(
+                    model, [{"role": "user", "content": "hi"}],
                 )
         finally:
             await teardown()
 
+    @pytest.mark.asyncio
+    async def test_streaming_404_logs_at_warning_not_error(self, caplog):
+        result = await self._run_streaming(
+            lambda req: httpx.Response(404, json={"error": {"message": "no endpoints"}}),
+            caplog, model="dead-model",
+        )
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Streaming-mode 404 should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Streaming-mode per-model 404 must not log at ERROR; got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Streaming-mode 404",
         )
 
     @pytest.mark.asyncio
     async def test_streaming_500_logs_at_warning_not_error(self, caplog):
-        """Streaming-mode non-retryable 5xx is gracefully handled."""
-        teardown = self._install_streaming_handler(
+        result = await self._run_streaming(
             lambda req: httpx.Response(500, text="server error"),
+            caplog,
         )
-        try:
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model_streaming(
-                    "model-a", [{"role": "user", "content": "hi"}],
-                )
-        finally:
-            await teardown()
-
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Streaming-mode 500 should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Streaming-mode per-model 500 must not log at ERROR; got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Streaming-mode 500",
         )
 
     @pytest.mark.asyncio
     async def test_streaming_401_still_logs_at_error(self, caplog):
-        """Streaming-mode auth failures keep ERROR severity."""
-        teardown = self._install_streaming_handler(
+        result = await self._run_streaming(
             lambda req: httpx.Response(401, json={"error": {"message": "unauthorized"}}),
+            caplog,
         )
-        try:
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model_streaming(
-                    "model-a", [{"role": "user", "content": "hi"}],
-                )
-        finally:
-            await teardown()
-
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "Streaming 401 must still log at ERROR"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="Streaming 401",
+        )
 
     @pytest.mark.asyncio
     async def test_streaming_402_still_logs_at_error(self, caplog):
-        """Streaming-mode billing failures keep ERROR severity."""
-        teardown = self._install_streaming_handler(
+        result = await self._run_streaming(
             lambda req: httpx.Response(402, json={"error": {"message": "insufficient credits"}}),
+            caplog,
         )
-        try:
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model_streaming(
-                    "model-a", [{"role": "user", "content": "hi"}],
-                )
-        finally:
-            await teardown()
-
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "Streaming 402 must still log at ERROR"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="Streaming 402",
+        )
 
     @pytest.mark.asyncio
     async def test_streaming_timeout_logs_at_warning(self, caplog):
-        """Streaming-mode post-retry timeout is gracefully handled."""
-
         def raise_timeout(req: httpx.Request) -> httpx.Response:
             raise httpx.TimeoutException("timed out", request=req)
 
-        teardown = self._install_streaming_handler(raise_timeout)
-        try:
-            with (
-                caplog.at_level("DEBUG", logger="backend.openrouter"),
-                patch("backend.openrouter.RETRY_BASE_DELAY", 0),
-            ):
-                result = await query_model_streaming(
-                    "model-a", [{"role": "user", "content": "hi"}],
-                )
-        finally:
-            await teardown()
-
+        result = await self._run_streaming(raise_timeout, caplog, retry_zero=True)
         assert is_model_error(result)
-        warning_records = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "backend.openrouter"
-        ]
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert warning_records, "Streaming-mode timeout should still emit a WARNING breadcrumb"
-        assert error_records == [], (
-            f"Streaming-mode per-model timeout must not log at ERROR; got: "
-            f"{[r.getMessage() for r in error_records]}"
+        _assert_log_severity(
+            caplog, expect_warning=True, expect_error=False, context="Streaming-mode timeout",
         )
 
     @pytest.mark.asyncio
     async def test_streaming_unexpected_exception_still_logs_at_error(self, caplog):
-        """Streaming-mode unexpected exceptions keep ERROR severity."""
-
         def raise_runtime(req: httpx.Request) -> httpx.Response:
             raise RuntimeError("something broke")
 
-        teardown = self._install_streaming_handler(raise_runtime)
-        try:
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model_streaming(
-                    "model-a", [{"role": "user", "content": "hi"}],
-                )
-        finally:
-            await teardown()
-
+        result = await self._run_streaming(raise_runtime, caplog)
         assert is_model_error(result)
-        error_records = [
-            r for r in caplog.records
-            if r.levelname == "ERROR" and r.name == "backend.openrouter"
-        ]
-        assert len(error_records) >= 1, "Streaming unexpected exceptions must still log at ERROR"
+        _assert_log_severity(
+            caplog, expect_warning=False, expect_error=True, context="Streaming unexpected exception",
+        )

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+import backend.openrouter as openrouter_module
 from backend.openrouter import (
     MAX_RETRIES,
     RETRYABLE_STATUS_CODES,
@@ -15,6 +16,7 @@ from backend.openrouter import (
     get_shared_client,
     is_model_error,
     query_model,
+    query_model_streaming,
 )
 
 
@@ -252,9 +254,11 @@ class TestQueryModelLogLevels:
         """A 404 on a single model (e.g., deprecated endpoint) is gracefully handled."""
         mock_post = AsyncMock(side_effect=self._make_status_error(404))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("dead-model", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("dead-model", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -271,9 +275,11 @@ class TestQueryModelLogLevels:
         """A non-retryable 5xx on a single model is gracefully handled."""
         mock_post = AsyncMock(side_effect=self._make_status_error(500))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -290,9 +296,11 @@ class TestQueryModelLogLevels:
         """Auth failures affect every request and warrant Sentry escalation."""
         mock_post = AsyncMock(side_effect=self._make_status_error(401))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -306,9 +314,11 @@ class TestQueryModelLogLevels:
         """Billing failures affect every request and warrant Sentry escalation."""
         mock_post = AsyncMock(side_effect=self._make_status_error(402))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -322,9 +332,11 @@ class TestQueryModelLogLevels:
         """Per-model timeout is gracefully handled, not a Sentry-grade error."""
         mock_post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -341,9 +353,11 @@ class TestQueryModelLogLevels:
         """Unknown/unexpected exceptions deserve full Sentry visibility."""
         mock_post = AsyncMock(side_effect=RuntimeError("something broke"))
 
-        with patch.object(get_shared_client(), "post", mock_post):
-            with caplog.at_level("DEBUG", logger="backend.openrouter"):
-                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+        with (
+            patch.object(get_shared_client(), "post", mock_post),
+            caplog.at_level("DEBUG", logger="backend.openrouter"),
+        ):
+            result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
         error_records = [
@@ -351,3 +365,170 @@ class TestQueryModelLogLevels:
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
         assert len(error_records) >= 1, "Unexpected exceptions must still log at ERROR"
+
+
+class TestQueryModelStreamingLogLevels:
+    """Mirror TestQueryModelLogLevels for the streaming code path.
+
+    The streaming function has its own HTTP error / timeout / unexpected-exception
+    branches. They must follow the same severity policy as the parallel path:
+    per-model failures are warnings, cross-cutting failures (auth/billing/unknown)
+    stay at error.
+    """
+
+    def _install_streaming_handler(self, handler):
+        """Replace the shared client with one whose transport is driven by ``handler``.
+
+        Returns a teardown callable that restores the previous client.
+        """
+        prev = openrouter_module._shared_client
+        transport = httpx.MockTransport(handler)
+        openrouter_module._shared_client = httpx.AsyncClient(transport=transport)
+
+        async def teardown():
+            await openrouter_module._shared_client.aclose()
+            openrouter_module._shared_client = prev
+
+        return teardown
+
+    @pytest.mark.asyncio
+    async def test_streaming_404_logs_at_warning_not_error(self, caplog):
+        """Streaming-mode 404 (deprecated model) is gracefully handled."""
+        teardown = self._install_streaming_handler(
+            lambda req: httpx.Response(404, json={"error": {"message": "no endpoints"}}),
+        )
+        try:
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model_streaming(
+                    "dead-model", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Streaming-mode per-model 404 must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_500_logs_at_warning_not_error(self, caplog):
+        """Streaming-mode non-retryable 5xx is gracefully handled."""
+        teardown = self._install_streaming_handler(
+            lambda req: httpx.Response(500, text="server error"),
+        )
+        try:
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model_streaming(
+                    "model-a", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Streaming-mode per-model 500 must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_401_still_logs_at_error(self, caplog):
+        """Streaming-mode auth failures keep ERROR severity."""
+        teardown = self._install_streaming_handler(
+            lambda req: httpx.Response(401, json={"error": {"message": "unauthorized"}}),
+        )
+        try:
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model_streaming(
+                    "model-a", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "Streaming 401 must still log at ERROR"
+
+    @pytest.mark.asyncio
+    async def test_streaming_402_still_logs_at_error(self, caplog):
+        """Streaming-mode billing failures keep ERROR severity."""
+        teardown = self._install_streaming_handler(
+            lambda req: httpx.Response(402, json={"error": {"message": "insufficient credits"}}),
+        )
+        try:
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model_streaming(
+                    "model-a", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "Streaming 402 must still log at ERROR"
+
+    @pytest.mark.asyncio
+    async def test_streaming_timeout_logs_at_warning(self, caplog):
+        """Streaming-mode post-retry timeout is gracefully handled."""
+
+        def raise_timeout(req: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException("timed out", request=req)
+
+        teardown = self._install_streaming_handler(raise_timeout)
+        try:
+            with (
+                caplog.at_level("DEBUG", logger="backend.openrouter"),
+                patch("backend.openrouter.RETRY_BASE_DELAY", 0),
+            ):
+                result = await query_model_streaming(
+                    "model-a", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Streaming-mode per-model timeout must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_unexpected_exception_still_logs_at_error(self, caplog):
+        """Streaming-mode unexpected exceptions keep ERROR severity."""
+
+        def raise_runtime(req: httpx.Request) -> httpx.Response:
+            raise RuntimeError("something broke")
+
+        teardown = self._install_streaming_handler(raise_runtime)
+        try:
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model_streaming(
+                    "model-a", [{"role": "user", "content": "hi"}],
+                )
+        finally:
+            await teardown()
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "Streaming unexpected exceptions must still log at ERROR"

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -261,6 +261,11 @@ def _assert_log_severity(
     error_records = _records(caplog, "ERROR")
     if expect_warning:
         assert warning_records, f"{context} should emit a WARNING breadcrumb"
+    else:
+        assert warning_records == [], (
+            f"{context} should not emit WARNING; got: "
+            f"{[r.getMessage() for r in warning_records]}"
+        )
     if expect_error:
         assert error_records, f"{context} should log at ERROR for Sentry visibility"
     else:

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -228,3 +228,126 @@ class TestQueryModel:
         assert result.status_code is None
         assert result.category == "unknown"
         assert "something broke" in result.message
+
+
+class TestQueryModelLogLevels:
+    """Per-model failures that the pipeline gracefully handles must not log at ERROR.
+
+    Sentry's LoggingIntegration captures ERROR-level records as events. When the
+    council pipeline degrades gracefully (some models fail, others succeed), each
+    per-model failure becoming a Sentry event is noise. Genuine cross-cutting
+    failures (auth, billing, unexpected exceptions) still escalate to ERROR.
+    """
+
+    def _make_status_error(self, status_code: int) -> httpx.HTTPStatusError:
+        resp = httpx.Response(
+            status_code=status_code,
+            text="error",
+            request=httpx.Request("POST", "https://example.com"),
+        )
+        return httpx.HTTPStatusError("err", request=resp.request, response=resp)
+
+    @pytest.mark.asyncio
+    async def test_404_logs_at_warning_not_error(self, caplog):
+        """A 404 on a single model (e.g., deprecated endpoint) is gracefully handled."""
+        mock_post = AsyncMock(side_effect=self._make_status_error(404))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("dead-model", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Per-model 404 must not log at ERROR (Sentry noise); got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_500_logs_at_warning_not_error(self, caplog):
+        """A non-retryable 5xx on a single model is gracefully handled."""
+        mock_post = AsyncMock(side_effect=self._make_status_error(500))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Per-model 500 must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_401_still_logs_at_error(self, caplog):
+        """Auth failures affect every request and warrant Sentry escalation."""
+        mock_post = AsyncMock(side_effect=self._make_status_error(401))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "401 must still log at ERROR for Sentry visibility"
+
+    @pytest.mark.asyncio
+    async def test_402_still_logs_at_error(self, caplog):
+        """Billing failures affect every request and warrant Sentry escalation."""
+        mock_post = AsyncMock(side_effect=self._make_status_error(402))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "402 must still log at ERROR for Sentry visibility"
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_at_warning(self, caplog):
+        """Per-model timeout is gracefully handled, not a Sentry-grade error."""
+        mock_post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert error_records == [], (
+            f"Per-model timeout must not log at ERROR; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_still_logs_at_error(self, caplog):
+        """Unknown/unexpected exceptions deserve full Sentry visibility."""
+        mock_post = AsyncMock(side_effect=RuntimeError("something broke"))
+
+        with patch.object(get_shared_client(), "post", mock_post):
+            with caplog.at_level("DEBUG", logger="backend.openrouter"):
+                result = await query_model("model-a", [{"role": "user", "content": "hi"}])
+
+        assert is_model_error(result)
+        error_records = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "backend.openrouter"
+        ]
+        assert len(error_records) >= 1, "Unexpected exceptions must still log at ERROR"

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -261,10 +261,15 @@ class TestQueryModelLogLevels:
             result = await query_model("dead-model", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Per-model 404 should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Per-model 404 must not log at ERROR (Sentry noise); got: "
             f"{[r.getMessage() for r in error_records]}"
@@ -282,10 +287,15 @@ class TestQueryModelLogLevels:
             result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Per-model 500 should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Per-model 500 must not log at ERROR; got: "
             f"{[r.getMessage() for r in error_records]}"
@@ -339,10 +349,15 @@ class TestQueryModelLogLevels:
             result = await query_model("model-a", [{"role": "user", "content": "hi"}])
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Per-model timeout should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Per-model timeout must not log at ERROR; got: "
             f"{[r.getMessage() for r in error_records]}"
@@ -406,10 +421,15 @@ class TestQueryModelStreamingLogLevels:
             await teardown()
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Streaming-mode 404 should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Streaming-mode per-model 404 must not log at ERROR; got: "
             f"{[r.getMessage() for r in error_records]}"
@@ -430,10 +450,15 @@ class TestQueryModelStreamingLogLevels:
             await teardown()
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Streaming-mode 500 should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Streaming-mode per-model 500 must not log at ERROR; got: "
             f"{[r.getMessage() for r in error_records]}"
@@ -501,10 +526,15 @@ class TestQueryModelStreamingLogLevels:
             await teardown()
 
         assert is_model_error(result)
+        warning_records = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "backend.openrouter"
+        ]
         error_records = [
             r for r in caplog.records
             if r.levelname == "ERROR" and r.name == "backend.openrouter"
         ]
+        assert warning_records, "Streaming-mode timeout should still emit a WARNING breadcrumb"
         assert error_records == [], (
             f"Streaming-mode per-model timeout must not log at ERROR; got: "
             f"{[r.getMessage() for r in error_records]}"


### PR DESCRIPTION
## Summary

- Per-model HTTP failures and post-retry timeouts now log at \`warning\` rather than \`error\`. The council pipeline already degrades gracefully, so each per-model failure becoming a Sentry event is noise.
- Auth (401), billing (402), and unexpected exceptions still escalate to \`error\` — they affect every request and warrant Sentry visibility.
- The aggregate \"all models failed\" branch in \`council_stream.py\` is unchanged and remains the correct Sentry escalation point.

Closes \`council-tvq\`. Companion to PR #55 (which fixed the duplicate-failure-per-request bug). Together these should substantially reduce Sentry events for the [LLM-COUNCIL-8](https://sentry.io/organizations/cameronsjo/issues/7366915323/) failure mode and others like it.

## Test plan

- [x] 6 new log-level assertions in \`TestQueryModelLogLevels\` covering 404, 500, 401, 402, timeout, unexpected exception
- [x] Failing tests reproduce the noise (3/6 fail before fix); passing after
- [x] Full suite: 241 passed
- [x] Lint: 6 pre-existing F401s unchanged, 0 new findings

## Why this is safe

Sentry's \`LoggingIntegration\` default \`event_level=ERROR\` means warning-level records still appear as breadcrumbs (full visibility for debugging) but no longer create issues. Logs themselves are unchanged in content — only the level moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-model HTTP and timeout failures now log as warnings during mixed-success (“graceful degradation”) scenarios; auth (401), billing (402), and unexpected exceptions still escalate as errors, and aggregate all-model failures continue to escalate.

* **Tests**
  * Added tests verifying logging severity and returned model-error behavior across failure types, for both streaming and non-streaming paths.

* **Documentation**
  * Updated changelog to document the revised logging and escalation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->