### PR TITLE
fix(openrouter): buffer streaming error body before context exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Streaming-mode HTTP errors now surface OpenRouter's error message detail (e.g.
+  `"No endpoints found for <model>"`) instead of the bare `"HTTP {status}"` fallback.
+  The response body is now buffered inside the streaming context manager before it
+  closes, so the parallel and streaming paths log identical detail for the same status.
+
 ## [0.7.0] - 2024-12-21
 
 ### Added

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -378,6 +378,13 @@ async def query_model_streaming(
                     headers=headers,
                     json=payload
                 ) as response:
+                    # Buffer the error body before the stream context closes.
+                    # Once the `async with` exits via HTTPStatusError, the underlying
+                    # connection closes and the response body becomes unreadable —
+                    # `_extract_error_message` would then fall back to bare "HTTP {status}"
+                    # instead of the OpenRouter detail. See council-rkt.
+                    if not response.is_success:
+                        await response.aread()
                     response.raise_for_status()
 
                     # Extract metadata from first chunk

--- a/tests/test_query_model.py
+++ b/tests/test_query_model.py
@@ -1,6 +1,7 @@
 """Tests for query_model: shared client, retry, differentiated errors."""
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -15,6 +16,7 @@ from backend.openrouter import (
     get_shared_client,
     is_model_error,
     query_model,
+    query_model_streaming,
 )
 
 
@@ -228,3 +230,105 @@ class TestQueryModel:
         assert result.status_code is None
         assert result.category == "unknown"
         assert "something broke" in result.message
+
+
+class TestQueryModelStreamingErrorDetail:
+    """Streaming-mode HTTP errors must surface OpenRouter's error message detail.
+
+    Regression test for council-rkt: in real httpx streaming, after the
+    `async with client.stream(...)` block exits via an HTTPStatusError, the
+    underlying connection closes and the response body becomes unreadable.
+    The body must be buffered (read) inside the context manager — otherwise
+    `_extract_error_message` falls back to the bare `"HTTP {status}"` string
+    instead of OpenRouter's actual error detail.
+    """
+
+    def _build_failing_stream_cm(self, status_code: int, body: dict):
+        """Build a fake httpx.client.stream() context manager that simulates real
+        streaming behavior: response body is unreadable after the CM exits, so
+        the only way to see the body is to call aread() inside the CM.
+
+        Returns a tuple (cm_factory, state) where state.aread_inside_cm reflects
+        whether body was buffered before exit.
+        """
+        body_bytes = json.dumps(body).encode()
+
+        class State:
+            cm_exited = False
+            aread_inside_cm = False
+
+        state = State()
+
+        class FakeStreamResponse:
+            def __init__(self):
+                self.status_code = status_code
+                self.is_success = 200 <= status_code < 300
+                self.headers = httpx.Headers()
+                self.request = httpx.Request("POST", "https://example.com")
+                self._buffered: bytes | None = None
+
+            async def aread(self) -> bytes:
+                # Inside CM: real streaming reads the body off the wire.
+                # Outside CM: the connection has closed; body is gone.
+                if state.cm_exited and self._buffered is None:
+                    return b""
+                if not state.cm_exited:
+                    state.aread_inside_cm = True
+                    self._buffered = body_bytes
+                return self._buffered or b""
+
+            def json(self):
+                if not self._buffered:
+                    raise json.JSONDecodeError("no body", "", 0)
+                return json.loads(self._buffered)
+
+            @property
+            def text(self) -> str:
+                return (self._buffered or b"").decode()
+
+            def raise_for_status(self):
+                if not self.is_success:
+                    raise httpx.HTTPStatusError(
+                        f"HTTP {self.status_code}",
+                        request=self.request,
+                        response=self,  # type: ignore[arg-type]
+                    )
+
+        response = FakeStreamResponse()
+
+        class FakeStreamCM:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *args):
+                state.cm_exited = True
+                return False
+
+        def cm_factory(*args, **kwargs):
+            return FakeStreamCM()
+
+        return cm_factory, state
+
+    @pytest.mark.asyncio
+    async def test_streaming_404_surfaces_openrouter_error_detail(self):
+        """Streaming-mode 404 must produce a ModelError carrying OpenRouter's detail."""
+        cm_factory, state = self._build_failing_stream_cm(
+            status_code=404,
+            body={"error": {"code": 404, "message": "No endpoints found for dead-model"}},
+        )
+
+        with patch.object(get_shared_client(), "stream", side_effect=cm_factory):
+            result = await query_model_streaming(
+                "dead-model", [{"role": "user", "content": "hi"}],
+            )
+
+        assert is_model_error(result)
+        assert result.status_code == 404
+        assert "No endpoints found for dead-model" in result.message, (
+            f"Streaming path lost OpenRouter error detail; got message: {result.message!r}. "
+            "Body must be buffered inside the stream CM (see council-rkt)."
+        )
+        assert state.aread_inside_cm, (
+            "Body was not read inside the streaming context manager — once the CM exits, "
+            "the body is unreadable in real httpx streams."
+        )


### PR DESCRIPTION
## Summary

In streaming mode, the response body wasn't being read before the \`async with client.stream(...)\` context closed via HTTPStatusError. By the time the except handler called \`_extract_error_message\`, the underlying connection was gone and \`aread()\` returned empty — so the log fell through to the bare \`"HTTP {status}"\` fallback.

Result for the [LLM-COUNCIL-8](https://sentry.io/organizations/cameronsjo/issues/7366915323/) failure mode:

| Path | Logged |
|------|--------|
| Parallel | \`HTTP error querying ... Detail: No endpoints found for google/gemini-3-pro-preview.\` |
| Streaming | \`HTTP error streaming ... Detail: HTTP 404\` (lost detail) |

Fix: when \`response.is_success\` is False, \`await response.aread()\` inside the streaming context to buffer \`_content\` before \`raise_for_status\` raises.

Closes \`council-rkt\`.

## Test plan

- [x] New regression test \`TestQueryModelStreamingErrorDetail::test_streaming_404_surfaces_openrouter_error_detail\` reproduces the bug with a fake stream context manager that mirrors real httpx closure semantics
- [x] Test fails before fix (\`got message: 'HTTP 404'\`), passes after (\`'No endpoints found for dead-model'\`)
- [x] Full suite: 236 passed
- [x] Lint: 6 pre-existing F401s unchanged, 0 new findings

## Why MockTransport wasn't enough

\`httpx.MockTransport\` pre-buffers response bodies into \`_content\`, so \`aread()\` always works regardless of context lifecycle. The bug only manifests with real network streaming (or a mock that simulates closure), so the test uses a custom CM that closes the body on \`__aexit__\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming mode HTTP errors now display OpenRouter's detailed error messages (e.g., "No endpoints found for model") instead of generic HTTP status fallbacks, ensuring consistent error reporting across all request modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->