### PR TITLE
chore(config): replace stale gemini-3-pro-preview defaults with gemini-2.5-pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace stale `google/gemini-3-pro-preview` defaults in `DEFAULT_COUNCIL_MODELS`
+  and `DEFAULT_CHAIRMAN_MODEL` with `google/gemini-2.5-pro`. The preview-tagged
+  model no longer has live OpenRouter endpoints (404 "No endpoints found"); the
+  GA model is the right long-term default.
+
 ## [0.7.0] - 2024-12-21
 
 ### Added

--- a/backend/arena.py
+++ b/backend/arena.py
@@ -136,7 +136,7 @@ def create_participant_mapping(models: list[str]) -> dict[str, str]:
 
     Returns:
         Dict mapping participant labels to model identifiers
-        e.g., {"Participant A": "openai/gpt-5.1", "Participant B": "google/gemini-3-pro"}
+        e.g., {"Participant A": "openai/gpt-5.1", "Participant B": "google/gemini-2.5-pro"}
     """
     labels = [chr(65 + i) for i in range(len(models))]  # A, B, C, ...
     return {f"Participant {label}": model for label, model in zip(labels, models)}

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,13 +24,13 @@ DATA_BASE_DIR = os.getenv("LLMCOUNCIL_DATA_DIR", "data")
 # Default council members - list of OpenRouter model identifiers
 DEFAULT_COUNCIL_MODELS = [
     "openai/gpt-5.1",
-    "google/gemini-3-pro-preview",
+    "google/gemini-2.5-pro",
     "anthropic/claude-sonnet-4.5",
     "x-ai/grok-4",
 ]
 
 # Default chairman model - synthesizes final response
-DEFAULT_CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
+DEFAULT_CHAIRMAN_MODEL = "google/gemini-2.5-pro"
 
 # Arena mode defaults
 DEFAULT_ARENA_ROUNDS = 3


### PR DESCRIPTION
## Summary

\`DEFAULT_COUNCIL_MODELS\` and \`DEFAULT_CHAIRMAN_MODEL\` pointed at \`google/gemini-3-pro-preview\`, inherited from the upstream karpathy v0 commit (2025-11-22). OpenRouter has since dropped its endpoints — fresh installs or any fallback path that hit the defaults would 404. See [LLM-COUNCIL-8](https://sentry.io/organizations/cameronsjo/issues/7366915323/) for the production fingerprint.

Switched both to \`google/gemini-2.5-pro\` (GA, low rotation risk). Also updated a matching docstring example in \`arena.py\` for consistency.

Closes \`council-lfv\`. Final PR in the [LLM-COUNCIL-8](https://sentry.io/organizations/cameronsjo/issues/7366915323/) cleanup series (#55, #56, #57).

## Test plan

- [x] No \`gemini-3-pro\` references remain anywhere in \`backend/\`, \`tests/\`, \`frontend/src/\`, \`docs/\`
- [x] Full suite: 235 passed
- [x] Pure config change — no behavior tests needed

## Caveat

This only fixes the *default* fallback. The user-facing impact comes from \`data/user_config.json\` and frontend-persisted model selections, which carry their own copies of model IDs. If your runtime selection still includes \`gemini-3-pro-preview\`, update via the model selector UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Swapped the system’s default Google AI model from the preview-tagged option to the stable GA model for both the LLM Council and chairman, aligning defaults to a version with live OpenRouter endpoints (avoids the previous “No endpoints found”/404 behavior).
* **Documentation**
  * Updated the example participant model identifier in the participant mapping docs to match the new default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->