### PR TITLE
Redesign: Deliberation Instrument theme (dark-first, seat colors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ frontend/.vite/
 
 # Claude Code local settings
 .claude/.playwright-mcp/
+.claude/agent-memory/
 
 # Git worktrees
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Re-skin frontend to "Deliberation Instrument" dark-first theme: charcoal (`#1A1D23`) dark
+  surfaces / warm-gray (`#EBEAE5`) light, ember orange (`#D76A3A`) for primary actions and the
+  chairman synthesis/verdict accent, Bricolage Grotesque headlines, Instrument Sans UI/body,
+  JetBrains Mono for all numeric data. Replaces the previous "Scholarly Deliberation Chamber"
+  theme (burgundy/gold/cream, Playfair Display). Adds a per-model seat-color system
+  (`lib/seatColors.js`, `hooks/useSeatColors.js`, `components/ui/`) and a CSS custom-property
+  token foundation in `index.css`.
 - Replace stale `google/gemini-3-pro-preview` defaults in `DEFAULT_COUNCIL_MODELS`
   and `DEFAULT_CHAIRMAN_MODEL` with `google/gemini-2.5-pro`. The preview-tagged
   model no longer has live OpenRouter endpoints (404 "No endpoints found"); the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ The key innovation is anonymized peer review, preventing models from playing fav
 
 **`components/Stage3.jsx`**
 - Final synthesized answer from chairman
-- Green-tinted background (#f0fff0) to highlight conclusion
+- Ember orange (#D76A3A) accent (border + header) marks the chairman verdict
 
 **`components/ArenaMode.jsx`**
 - Container for Arena debate display
@@ -133,9 +133,15 @@ The key innovation is anonymized peer review, preventing models from playing fav
 - Token usage and latency display
 - Per-model and aggregate statistics
 
-**Styling (`*.css`)**
-- Light mode theme (not dark mode)
-- Primary color: #4a90e2 (blue)
+**Styling (`*.css` + design system)**
+- Dark-first "Deliberation Instrument" theme — charcoal dark surfaces (`--bg` `#1A1D23`) with a warm-gray light mode (`#EBEAE5`); intentionally not pure black/white
+- Primary action color and chairman synthesis/verdict accent: ember orange (`--accent` `#D76A3A` light / `#E1865F` dark)
+- Fonts: Bricolage Grotesque (headlines), Instrument Sans (UI/body), JetBrains Mono (all numeric data + micro-labels)
+- Per-model seat-color system: each council model hashes to one of 5 seat colors — stable across sessions and council reordering, collision-nudged so a council of ≤5 stays distinct
+  - `frontend/src/lib/seatColors.js` — `hashString` + `assignSeats`: deterministic id→seat mapping returning `var(--seat-N)` token strings
+  - `frontend/src/hooks/useSeatColors.js` — hook over the live council (`config.council_models`); `seatOf(id)` → `{ seat, color, soft }`
+  - `frontend/src/components/ui/` — shared primitives (SeatAvatar, BrandMark, StageRail, ToggleSwitch, KpiCard) threaded with seat colors
+- CSS custom-property token foundation in `index.css` — semantic tokens (`--bg`/`--fg`/`--accent`/`--seat-1..5`/`--line`/`--font-*`) with synced light + dark blocks
 - Global markdown styling in `index.css` with `.markdown-content` class
 - 12px padding on all markdown content to prevent cluttered appearance
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,8 +16,8 @@
     <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Theme Color -->
-    <meta name="theme-color" content="#8b2635" />
-    <meta name="msapplication-TileColor" content="#8b2635" />
+    <meta name="theme-color" content="#D76A3A" />
+    <meta name="msapplication-TileColor" content="#1A1D23" />
 
     <!-- Open Graph / Social -->
     <meta property="og:type" content="website" />

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,18 +1,24 @@
-/* App Layout */
+/* ─────────────────────────────────────────────────────────────────────────────
+   App shell — "Deliberation Instrument" re-skin
+   Two-pane: fixed sidebar + flexible main column.
+   Dot-grid texture lives on .chat-interface (ChatInterface.css) and .standings.
+───────────────────────────────────────────────────────────────────────────── */
+
+/* ── Shell ──────────────────────────────────────────────────────────────── */
 .app {
   display: flex;
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-  background: var(--color-cream);
+  background: var(--bg);
   position: relative;
 }
 
-/* Elegant page entrance animation */
+/* Staggered entrance */
 @keyframes fadeSlideIn {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
@@ -20,17 +26,17 @@
   }
 }
 
-.app > .sidebar,
-.app > .chat-interface {
-  animation: fadeSlideIn 0.4s ease-out;
-  -webkit-backface-visibility: hidden;
+.app > .sidebar {
+  animation: fadeSlideIn var(--dur-deliberate) var(--ease-out);
 }
 
 .app > .chat-interface {
-  animation-delay: 0.1s;
+  animation: fadeSlideIn var(--dur-deliberate) var(--ease-out);
+  animation-delay: 80ms;
+  animation-fill-mode: both;
 }
 
-/* Auth Expired Banner */
+/* ── Auth expired banner ─────────────────────────────────────────────────── */
 .auth-expired-banner {
   position: fixed;
   top: 0;
@@ -42,30 +48,30 @@
   justify-content: center;
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-lg);
-  background: var(--color-error, #d32f2f);
-  color: white;
-  font-size: var(--font-sm);
+  background: var(--danger);
+  color: var(--fg-on-accent);
+  font-size: 13.5px;
   font-weight: 500;
-  box-shadow: var(--shadow-medium);
+  box-shadow: var(--shadow-md);
 }
 
 .auth-expired-banner button {
-  padding: var(--space-xs) var(--space-md);
-  background: white;
-  color: var(--color-error, #d32f2f);
+  padding: 5px var(--space-md);
+  background: var(--fg-on-accent);
+  color: var(--danger);
   border: none;
   border-radius: var(--radius-sm);
-  font-size: var(--font-sm);
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: opacity var(--transition-fast);
+  transition: opacity var(--dur-micro) var(--ease-out);
 }
 
 .auth-expired-banner button:hover {
-  opacity: 0.9;
+  opacity: 0.88;
 }
 
-/* Mobile Menu Toggle */
+/* ── Mobile menu toggle ──────────────────────────────────────────────────── */
 .mobile-menu-toggle {
   display: none;
   position: fixed;
@@ -73,42 +79,49 @@
   left: var(--space-md);
   z-index: 1001;
   padding: var(--space-sm);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  color: var(--color-text-primary);
+  color: var(--fg-muted);
   cursor: pointer;
-  box-shadow: var(--shadow-medium);
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .mobile-menu-toggle:hover {
-  background: var(--color-ivory);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
 }
 
 .mobile-menu-toggle:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
-/* Sidebar Backdrop (mobile) */
+/* ── Sidebar backdrop (mobile) ───────────────────────────────────────────── */
 .sidebar-backdrop {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.35);
   z-index: 998;
-  animation: fadeIn 0.2s ease-out;
+  animation: fadeIn var(--dur-standard) var(--ease-out);
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
-/* Mobile Responsive Styles */
+/* ── Responsive ──────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
   .mobile-menu-toggle {
     display: flex;
@@ -132,7 +145,7 @@
 
   .app.sidebar-open .sidebar {
     transform: translateX(0);
-    box-shadow: var(--shadow-elevated);
+    box-shadow: var(--shadow-lg);
   }
 
   .app.sidebar-closed .sidebar-backdrop {
@@ -142,9 +155,16 @@
   .app .chat-interface {
     width: 100%;
   }
+}
 
-  /* Add padding for mobile menu button */
-  .app .chat-interface .messages-container {
-    padding-top: 60px;
+@media (prefers-reduced-motion: reduce) {
+  .app > .sidebar,
+  .app > .chat-interface,
+  .sidebar-backdrop {
+    animation: none;
+  }
+
+  .app .sidebar {
+    transition: none;
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -434,6 +434,7 @@ function App() {
       <Sidebar
         onSelectConversation={handleSelectConversationMobile}
         onNewConversation={handleNewConversation}
+        isLoading={isLoading}
       />
       {currentView === 'standings' ? (
         <Standings />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -453,6 +453,7 @@ function App() {
           onRetryRankings={handleRetryRankings}
           onRetryAll={handleRetryAll}
           onCancel={cancelStream}
+          onExportConversation={handleExportConversation}
         />
       )}
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ function App() {
   const currentConversationId = useUIStore((s) => s.currentConversationId);
   const setCurrentConversationId = useUIStore((s) => s.setCurrentConversationId);
   const currentView = useUIStore((s) => s.currentView);
+  const setCurrentView = useUIStore((s) => s.setCurrentView);
   const mode = useUIStore((s) => s.mode);
   const setMode = useUIStore((s) => s.setMode);
   const arenaRoundCount = useUIStore((s) => s.arenaRoundCount);
@@ -103,10 +104,16 @@ function App() {
             role: 'assistant',
             partial: true,
             mode: pending.mode,
-            rounds: partialData.rounds || (partialData.responses ? [{
-              round_type: 'responses',
-              responses: partialData.responses,
-            }] : null),
+            rounds:
+              partialData.rounds ||
+              (partialData.responses
+                ? [
+                    {
+                      round_type: 'responses',
+                      responses: partialData.responses,
+                    },
+                  ]
+                : null),
             synthesis: partialData.synthesis || null,
             participant_mapping: partialData.participant_mapping || null,
           };
@@ -126,7 +133,13 @@ function App() {
     } else {
       setCurrentConversation(conv);
     }
-  }, [conversationQuery.data, pendingStatusQuery.data, pendingStatusQuery.isLoading, currentConversationId, setCurrentConversation]);
+  }, [
+    conversationQuery.data,
+    pendingStatusQuery.data,
+    pendingStatusQuery.isLoading,
+    currentConversationId,
+    setCurrentConversation,
+  ]);
 
   // Cancel stream when switching conversations
   useEffect(() => {
@@ -157,6 +170,7 @@ function App() {
     try {
       const newConv = await createConversation.mutateAsync({ councilModels, chairmanModel });
       setCurrentConversationId(newConv.id);
+      setCurrentView('chat');
     } catch (error) {
       if (error instanceof AuthRedirectError) {
         setAuthExpired(true);
@@ -164,7 +178,14 @@ function App() {
       }
       console.error('Failed to create conversation:', error);
     }
-  }, [createConversation, councilModels, chairmanModel, setCurrentConversationId, setAuthExpired]);
+  }, [
+    createConversation,
+    councilModels,
+    chairmanModel,
+    setCurrentConversationId,
+    setCurrentView,
+    setAuthExpired,
+  ]);
 
   // Global keyboard shortcuts
   useEffect(() => {
@@ -179,88 +200,154 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleNewConversation]);
 
-  const handleSelectConversationMobile = useCallback((id) => {
-    setCurrentConversationId(id);
-    if (window.innerWidth <= 768) {
-      setSidebarOpen(false);
-    }
-  }, [setCurrentConversationId, setSidebarOpen]);
-
-  const handleSendMessage = useCallback(async (content, attachments = [], resume = false) => {
-    if (!currentConversationId) return;
-    const priorContext = useUIStore.getState().pendingForkContext;
-    if (priorContext) setPendingForkContext(null);
-    await sendMessage(currentConversationId, content, attachments, {
-      mode, useWebSearch, arenaRoundCount, resume, priorContext,
-    });
-  }, [currentConversationId, sendMessage, mode, useWebSearch, arenaRoundCount, setPendingForkContext]);
-
-  const handleRetry = useCallback(async (content) => {
-    if (!currentConversationId || !currentConversation) return;
-    const conv = await api.getConversation(currentConversationId);
-    setCurrentConversation(conv);
-    await handleSendMessage(content);
-  }, [currentConversationId, currentConversation, setCurrentConversation, handleSendMessage]);
-
-  const handleRetryInterrupted = useCallback(async (shouldResume = false) => {
-    if (!currentConversationId || !currentConversation?.pendingInfo) return;
-
-    const userContent = currentConversation.pendingInfo.user_content;
-    const pendingMode = currentConversation.pendingInfo.mode || 'council';
-    const hasStage1 =
-      (currentConversation.pendingInfo.partial_data?.responses?.length > 0) ||
-      (currentConversation.pendingInfo.partial_data?.stage1?.length > 0);
-
-    if (shouldResume && hasStage1) {
-      setMode(pendingMode);
-      await handleSendMessage(userContent, [], true);
-    } else {
-      try {
-        await clearPending.mutateAsync(currentConversationId);
-        const conv = await api.getConversation(currentConversationId);
-        setCurrentConversation(conv);
-      } catch (error) {
-        if (error instanceof AuthRedirectError) { setAuthExpired(true); return; }
-        console.warn('Failed to clear pending on server, retrying with local state:', error.message);
-        const cleanMessages = (currentConversation.messages || []).filter((m) => !m.partial);
-        setCurrentConversation({ ...currentConversation, pendingInterrupted: false, pendingInfo: null, messages: cleanMessages });
+  const handleSelectConversationMobile = useCallback(
+    (id) => {
+      setCurrentConversationId(id);
+      setCurrentView('chat');
+      if (window.innerWidth <= 768) {
+        setSidebarOpen(false);
       }
+    },
+    [setCurrentConversationId, setCurrentView, setSidebarOpen]
+  );
 
-      setMode(pendingMode);
-      await handleSendMessage(userContent);
-    }
-  }, [currentConversationId, currentConversation, clearPending, setCurrentConversation, setMode, setAuthExpired, handleSendMessage]);
+  const handleSendMessage = useCallback(
+    async (content, attachments = [], resume = false) => {
+      if (!currentConversationId) return;
+      const priorContext = useUIStore.getState().pendingForkContext;
+      if (priorContext) setPendingForkContext(null);
+      await sendMessage(currentConversationId, content, attachments, {
+        mode,
+        useWebSearch,
+        arenaRoundCount,
+        resume,
+        priorContext,
+      });
+    },
+    [currentConversationId, sendMessage, mode, useWebSearch, arenaRoundCount, setPendingForkContext]
+  );
+
+  const handleRetry = useCallback(
+    async (content) => {
+      if (!currentConversationId || !currentConversation) return;
+      const conv = await api.getConversation(currentConversationId);
+      setCurrentConversation(conv);
+      await handleSendMessage(content);
+    },
+    [currentConversationId, currentConversation, setCurrentConversation, handleSendMessage]
+  );
+
+  const handleRetryInterrupted = useCallback(
+    async (shouldResume = false) => {
+      if (!currentConversationId || !currentConversation?.pendingInfo) return;
+
+      const userContent = currentConversation.pendingInfo.user_content;
+      const pendingMode = currentConversation.pendingInfo.mode || 'council';
+      const hasStage1 =
+        currentConversation.pendingInfo.partial_data?.responses?.length > 0 ||
+        currentConversation.pendingInfo.partial_data?.stage1?.length > 0;
+
+      if (shouldResume && hasStage1) {
+        setMode(pendingMode);
+        await handleSendMessage(userContent, [], true);
+      } else {
+        try {
+          await clearPending.mutateAsync(currentConversationId);
+          const conv = await api.getConversation(currentConversationId);
+          setCurrentConversation(conv);
+        } catch (error) {
+          if (error instanceof AuthRedirectError) {
+            setAuthExpired(true);
+            return;
+          }
+          console.warn(
+            'Failed to clear pending on server, retrying with local state:',
+            error.message
+          );
+          const cleanMessages = (currentConversation.messages || []).filter((m) => !m.partial);
+          setCurrentConversation({
+            ...currentConversation,
+            pendingInterrupted: false,
+            pendingInfo: null,
+            messages: cleanMessages,
+          });
+        }
+
+        setMode(pendingMode);
+        await handleSendMessage(userContent);
+      }
+    },
+    [
+      currentConversationId,
+      currentConversation,
+      clearPending,
+      setCurrentConversation,
+      setMode,
+      setAuthExpired,
+      handleSendMessage,
+    ]
+  );
 
   const handleDismissInterrupted = useCallback(async () => {
     if (!currentConversationId) return;
 
     // Clear UI immediately
     const cleanMessages = (currentConversation?.messages || []).filter((m) => !m.partial);
-    setCurrentConversation({ ...currentConversation, pendingInterrupted: false, pendingInfo: null, messages: cleanMessages });
+    setCurrentConversation({
+      ...currentConversation,
+      pendingInterrupted: false,
+      pendingInfo: null,
+      messages: cleanMessages,
+    });
 
     // Fire-and-forget server cleanup
     try {
       await clearPending.mutateAsync(currentConversationId);
     } catch (error) {
-      if (error instanceof AuthRedirectError) { setAuthExpired(true); return; }
-      console.warn('Failed to clear pending on server (will be cleaned up on next load):', error.message);
+      if (error instanceof AuthRedirectError) {
+        setAuthExpired(true);
+        return;
+      }
+      console.warn(
+        'Failed to clear pending on server (will be cleaned up on next load):',
+        error.message
+      );
     }
-  }, [currentConversationId, currentConversation, clearPending, setCurrentConversation, setAuthExpired]);
+  }, [
+    currentConversationId,
+    currentConversation,
+    clearPending,
+    setCurrentConversation,
+    setAuthExpired,
+  ]);
 
-  const handleForkConversation = useCallback(async (originalQuestion, synthesis, sourceConversationId) => {
-    try {
-      const newConv = await createConversation.mutateAsync({ councilModels, chairmanModel });
-      setCurrentConversationId(newConv.id);
-      setPendingForkContext({
-        original_question: originalQuestion,
-        synthesis: synthesis,
-        source_conversation_id: sourceConversationId,
-      });
-    } catch (error) {
-      if (error instanceof AuthRedirectError) { setAuthExpired(true); return; }
-      console.error('Failed to fork conversation:', error);
-    }
-  }, [createConversation, councilModels, chairmanModel, setCurrentConversationId, setPendingForkContext, setAuthExpired]);
+  const handleForkConversation = useCallback(
+    async (originalQuestion, synthesis, sourceConversationId) => {
+      try {
+        const newConv = await createConversation.mutateAsync({ councilModels, chairmanModel });
+        setCurrentConversationId(newConv.id);
+        setPendingForkContext({
+          original_question: originalQuestion,
+          synthesis: synthesis,
+          source_conversation_id: sourceConversationId,
+        });
+      } catch (error) {
+        if (error instanceof AuthRedirectError) {
+          setAuthExpired(true);
+          return;
+        }
+        console.error('Failed to fork conversation:', error);
+      }
+    },
+    [
+      createConversation,
+      councilModels,
+      chairmanModel,
+      setCurrentConversationId,
+      setPendingForkContext,
+      setAuthExpired,
+    ]
+  );
 
   const handleExtendDebate = useCallback(async () => {
     if (!currentConversationId || isExtendingDebate) return;
@@ -282,31 +369,36 @@ function App() {
     await retryAll(currentConversationId);
   }, [currentConversationId, isLoading, retryAll]);
 
-  const handleExportConversation = useCallback(async (id, format) => {
-    try {
-      const blob = format === 'markdown'
-        ? await api.exportMarkdown(id)
-        : await api.exportJson(id);
+  const handleExportConversation = useCallback(
+    async (id, format) => {
+      try {
+        const blob =
+          format === 'markdown' ? await api.exportMarkdown(id) : await api.exportJson(id);
 
-      const conversations = conversationsQuery.data ?? [];
-      const conv = conversations.find((c) => c.id === id);
-      const title = (conv?.title || 'conversation').replace(/[^a-zA-Z0-9]/g, '_');
-      const extension = format === 'markdown' ? 'md' : 'json';
-      const filename = `${title}.${extension}`;
+        const conversations = conversationsQuery.data ?? [];
+        const conv = conversations.find((c) => c.id === id);
+        const title = (conv?.title || 'conversation').replace(/[^a-zA-Z0-9]/g, '_');
+        const extension = format === 'markdown' ? 'md' : 'json';
+        const filename = `${title}.${extension}`;
 
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      if (error instanceof AuthRedirectError) { setAuthExpired(true); return; }
-      console.error('Failed to export conversation:', error);
-    }
-  }, [conversationsQuery.data, setAuthExpired]);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        if (error instanceof AuthRedirectError) {
+          setAuthExpired(true);
+          return;
+        }
+        console.error('Failed to export conversation:', error);
+      }
+    },
+    [conversationsQuery.data, setAuthExpired]
+  );
 
   // ── Render ────────────────────────────────────────────────────────────
 
@@ -315,10 +407,8 @@ function App() {
       {/* Auth expired banner */}
       {authExpired && (
         <div className="auth-expired-banner" role="alert">
-          <span>Session expired — please re-authenticate to continue.</span>
-          <button onClick={() => window.location.reload()}>
-            Re-authenticate
-          </button>
+          <span>Session expired — re-authenticate to continue.</span>
+          <button onClick={() => window.location.reload()}>Re-authenticate</button>
         </div>
       )}
 

--- a/frontend/src/__tests__/seatColors.test.js
+++ b/frontend/src/__tests__/seatColors.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { SEAT_COUNT, hashString, seatTokens, rawSeat, assignSeats } from '../lib/seatColors.js';
+
+describe('hashString', () => {
+  it('is deterministic', () => {
+    expect(hashString('openai/gpt-5.1')).toBe(hashString('openai/gpt-5.1'));
+  });
+
+  it('returns an unsigned 32-bit integer', () => {
+    for (const id of ['a', 'openai/gpt-4o', 'anthropic/claude-sonnet-4', '']) {
+      const h = hashString(id);
+      expect(Number.isInteger(h)).toBe(true);
+      expect(h).toBeGreaterThanOrEqual(0);
+      expect(h).toBeLessThanOrEqual(0xffffffff);
+    }
+  });
+
+  it('distinguishes different ids', () => {
+    expect(hashString('alpha')).not.toBe(hashString('beta'));
+  });
+});
+
+describe('seatTokens', () => {
+  it('builds the CSS var bundle for a seat number', () => {
+    expect(seatTokens(3)).toEqual({
+      seat: 3,
+      color: 'var(--seat-3)',
+      soft: 'var(--seat-3-soft)',
+    });
+  });
+});
+
+describe('rawSeat', () => {
+  it('is a stable 1..SEAT_COUNT index for an id, independent of any roster', () => {
+    const s = rawSeat('meta/llama-3.3-70b');
+    expect(s).toBe(rawSeat('meta/llama-3.3-70b'));
+    expect(s).toBeGreaterThanOrEqual(1);
+    expect(s).toBeLessThanOrEqual(SEAT_COUNT);
+  });
+});
+
+describe('assignSeats', () => {
+  const council = [
+    'openai/gpt-4o',
+    'anthropic/claude-sonnet-4',
+    'google/gemini-2.5-pro',
+    'meta/llama-3.3-70b',
+    'x-ai/grok-2',
+  ];
+
+  it('returns a Map keyed by model id with seat token bundles', () => {
+    const map = assignSeats(council);
+    expect(map).toBeInstanceOf(Map);
+    expect(map.size).toBe(council.length);
+    for (const id of council) {
+      const t = map.get(id);
+      expect(t.seat).toBeGreaterThanOrEqual(1);
+      expect(t.seat).toBeLessThanOrEqual(SEAT_COUNT);
+      expect(t.color).toBe(`var(--seat-${t.seat})`);
+      expect(t.soft).toBe(`var(--seat-${t.seat}-soft)`);
+    }
+  });
+
+  it('is deterministic for the same roster', () => {
+    expect([...assignSeats(council)]).toEqual([...assignSeats(council)]);
+  });
+
+  it('is stable across council reordering (set-based, not order-based)', () => {
+    const reversed = [...council].reverse();
+    const a = assignSeats(council);
+    const b = assignSeats(reversed);
+    for (const id of council) {
+      expect(b.get(id)).toEqual(a.get(id));
+    }
+  });
+
+  it('keeps a council of <=5 visually distinct (no shared seats)', () => {
+    const map = assignSeats(council);
+    const seats = [...map.values()].map((t) => t.seat);
+    expect(new Set(seats).size).toBe(council.length);
+  });
+
+  it('allows repeats once every seat is in use (>5 models)', () => {
+    const big = [...council, 'mistralai/mistral-large', 'cohere/command-r'];
+    const map = assignSeats(big);
+    expect(map.size).toBe(big.length);
+    const seats = [...map.values()].map((t) => t.seat);
+    // 7 models into 5 seats -> some seat is necessarily reused.
+    expect(new Set(seats).size).toBe(SEAT_COUNT);
+    for (const s of seats) {
+      expect(s).toBeGreaterThanOrEqual(1);
+      expect(s).toBeLessThanOrEqual(SEAT_COUNT);
+    }
+  });
+
+  it('dedupes repeated ids and tolerates null/undefined entries', () => {
+    const map = assignSeats(['a', 'a', null, undefined, 'b']);
+    expect(map.size).toBe(2);
+    expect(map.has('a')).toBe(true);
+    expect(map.has('b')).toBe(true);
+  });
+
+  it('returns an empty map for empty or non-array input', () => {
+    expect(assignSeats([]).size).toBe(0);
+    expect(assignSeats(undefined).size).toBe(0);
+    expect(assignSeats(null).size).toBe(0);
+  });
+});

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -26,6 +26,7 @@
   height: 56px;
   flex: none;
   border-bottom: 1px solid var(--line);
+  background: var(--bg);
   background: color-mix(in srgb, var(--bg) 86%, transparent);
   backdrop-filter: blur(8px);
   display: flex;
@@ -1339,6 +1340,17 @@
 .attachment-remove:focus-visible {
   outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
+}
+
+.ask-box-textarea:focus-visible,
+.ask-bar-input:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 0;
+}
+
+.rounds-slider:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 3px;
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -466,6 +466,27 @@
   margin-bottom: 26px;
 }
 
+/* Deliberation blocks stagger in on first paint (~60ms each).
+   Neutralized by the global prefers-reduced-motion guard in index.css. */
+.assistant-message > * {
+  animation: ccFade var(--dur-deliberate) var(--ease-out) both;
+}
+.assistant-message > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.assistant-message > *:nth-child(2) {
+  animation-delay: 60ms;
+}
+.assistant-message > *:nth-child(3) {
+  animation-delay: 120ms;
+}
+.assistant-message > *:nth-child(4) {
+  animation-delay: 180ms;
+}
+.assistant-message > *:nth-child(n + 5) {
+  animation-delay: 240ms;
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    STAGE SECTION HEADERS (council mode)
 ───────────────────────────────────────────────────────────────────────────── */

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -1,118 +1,311 @@
-/* Chat Interface - Main Content Area */
+/* ─────────────────────────────────────────────────────────────────────────────
+   ChatInterface — "Deliberation Instrument" re-skin
+   Token-only: uses --bg/--fg/--seat-N/--accent etc. from index.css :root.
+   No hardcoded hex; no legacy --color-* references.
+───────────────────────────────────────────────────────────────────────────── */
+
+/* ── Shell ──────────────────────────────────────────────────────────────── */
 .chat-interface {
   flex: 1;
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: var(--color-cream);
+  min-width: 0;
   position: relative;
+  background-color: var(--bg);
+  background-image: radial-gradient(var(--grid) 1px, transparent 1px);
+  background-size: 22px 22px;
 }
 
-.messages-container {
+/* ─────────────────────────────────────────────────────────────────────────────
+   LANDING STATE
+───────────────────────────────────────────────────────────────────────────── */
+.landing-scroll {
   flex: 1;
   overflow-y: auto;
-  padding: var(--space-xl) var(--space-2xl);
-}
-
-/* Empty State */
-.empty-state {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  text-align: center;
-  padding: var(--space-xl);
+  padding: 24px;
 }
 
-.empty-state h2 {
-  font-family: var(--font-display);
-  font-size: 1.5rem;
+.landing-content {
+  max-width: 720px;
+  width: 100%;
+  padding: 48px 0 36px;
+}
+
+/* Status pill */
+.landing-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  margin-bottom: 22px;
+}
+
+.landing-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex: none;
+}
+
+.landing-status-text {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--fg-subtle);
+  letter-spacing: 0.02em;
+}
+
+/* Hero */
+.landing-hero-h1 {
+  font-family: var(--font-head);
+  font-size: 43px;
   font-weight: 600;
-  margin: 0 0 var(--space-md) 0;
-  color: var(--color-text-primary);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  margin-bottom: 14px;
+  color: var(--fg);
 }
 
-.empty-state p {
-  margin: 0 0 var(--space-xl) 0;
-  font-size: 0.9375rem;
-  color: var(--color-text-secondary);
-  max-width: 400px;
-  line-height: 1.6;
+.landing-hero-faint {
+  color: var(--fg-faint);
 }
 
-/* Prompt Suggestions */
-.prompt-suggestions {
+.landing-hero-sub {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--fg-subtle);
+  max-width: 520px;
+  margin-bottom: 30px;
+}
+
+/* Seat cards */
+.landing-seats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 28px;
+}
+
+.seat-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-md);
-  padding-top: var(--space-lg);
-  border-top: 1px dashed var(--color-border);
-  max-width: 500px;
+  gap: 6px;
+  padding: 12px 8px;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  text-align: center;
 }
 
-.suggestions-label {
+.seat-card--chair {
+  border-color: var(--accent);
+}
+
+.seat-card-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--fg);
+  line-height: 1.2;
+  word-break: break-all;
+}
+
+.seat-card-role {
+  font-size: 9.5px;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
 }
 
-.prompt-chips {
+/* Ask box */
+.ask-box {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--shadow-md);
+  padding: 6px;
+  margin-bottom: 14px;
+}
+
+.ask-box-textarea {
+  width: 100%;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 14px 14px 6px 14px;
+  font-family: var(--font-display);
+  font-size: 15.5px;
+  color: var(--fg);
+  line-height: 1.45;
+  min-height: 64px;
+}
+
+.ask-box-textarea::placeholder {
+  color: var(--fg-faint);
+}
+
+.ask-box-textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ask-box-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px 8px 12px;
+}
+
+.ask-box-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Prompt chips */
+.landing-prompt-chips {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-sm);
+  gap: 8px;
+  margin-top: 14px;
 }
 
-.prompt-chip {
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+.landing-prompt-chip {
+  padding: 7px 12px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  color: var(--fg-subtle);
+  font-family: var(--font-display);
+  font-size: 12.5px;
   cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.prompt-chip:hover {
-  background: var(--color-ivory);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-subtle);
+.landing-prompt-chip:hover {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
 }
 
-.prompt-chip:active {
-  transform: translateY(0);
-}
-
-.prompt-chip:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+.landing-prompt-chip:focus-visible {
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
-.empty-state-icon {
-  width: 160px;
-  height: 160px;
-  margin-bottom: var(--space-lg);
+/* ─────────────────────────────────────────────────────────────────────────────
+   SHARED CONTROLS
+───────────────────────────────────────────────────────────────────────────── */
+
+/* Ghost chips — web search / attach */
+.ghost-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-/* Message Groups */
+.ghost-chip:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
+}
+
+.ghost-chip--active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.ghost-chip--active:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.ghost-chip:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Convene / open-debate button */
+.convene-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
+}
+
+.convene-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.convene-btn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.convene-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Hidden file input */
+.file-input-hidden {
+  display: none;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   MESSAGES CONTAINER
+───────────────────────────────────────────────────────────────────────────── */
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 28px 28px 24px;
+}
+
+/* ── Message groups ──────────────────────────────────────────────────────── */
 .message-group {
-  margin-bottom: var(--space-2xl);
-  animation: messageSlideIn 0.4s ease-out;
-  -webkit-backface-visibility: hidden;
+  margin-bottom: 32px;
+  animation: messageSlideIn var(--dur-deliberate) var(--ease-out);
 }
 
 @keyframes messageSlideIn {
   from {
     opacity: 0;
-    transform: translateY(12px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
@@ -120,137 +313,346 @@
   }
 }
 
-.user-message,
-.assistant-message {
-  margin-bottom: var(--space-md);
+/* User message */
+.user-message {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 26px;
 }
 
-/* Message Header with Actions */
+.user-badge {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--line);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--fg-subtle);
+  flex: none;
+  letter-spacing: 0.01em;
+}
+
+.user-message-body {
+  padding-top: 4px;
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--fg);
+  position: relative;
+}
+
+/* Message header — label + action buttons */
 .message-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--space-sm);
+  margin-bottom: 12px;
 }
 
 .message-label {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 10.5px;
   font-weight: 600;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.partial-badge {
-  font-size: 0.625rem;
-  font-weight: 500;
-  padding: 2px 6px;
-  background: var(--color-stage2);
-  border: 1px solid var(--color-stage2-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-stage2-accent);
-  text-transform: uppercase;
-}
-
-.partial-response {
-  border-left: 3px solid var(--color-stage2-accent);
-  opacity: 0.9;
+  letter-spacing: 0.06em;
 }
 
 .message-actions {
   display: flex;
-  gap: var(--space-xs);
+  gap: 6px;
   opacity: 0;
-  transition: opacity var(--transition-fast);
+  transform: translateX(6px);
+  transition:
+    opacity var(--dur-micro) var(--ease-out),
+    transform var(--dur-standard) var(--ease-out);
 }
 
-.message-group:hover .message-actions {
+.message-group:hover .message-actions,
+.message-group:focus-within .message-actions {
   opacity: 1;
+  transform: translateX(0);
 }
 
 .message-action-btn {
-  padding: 4px 8px;
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
+  color: var(--fg-subtle);
   cursor: pointer;
-  font-size: 0.75rem;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
-  color: var(--color-text-secondary);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .message-action-btn:hover {
-  background: var(--color-parchment);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
 }
 
-.message-action-btn.retry-btn:hover {
-  background: rgba(134, 70, 88, 0.1);
+/* Partial response */
+.partial-response {
+  border-left: 3px solid var(--warning);
+  padding-left: 12px;
+  opacity: 0.9;
 }
 
-/* User Message */
-.user-message .message-content {
-  background: linear-gradient(135deg, var(--color-ivory) 0%, var(--color-parchment) 100%);
-  padding: var(--space-lg);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  line-height: 1.7;
-  max-width: 75%;
-  box-shadow: var(--shadow-subtle);
-  position: relative;
+.partial-badge-row {
+  margin-bottom: 8px;
 }
 
-/* Decorative corner flourish */
-.user-message .message-content::before {
-  content: '';
-  position: absolute;
-  top: -1px;
-  left: -1px;
-  width: 24px;
-  height: 24px;
-  border-left: 2px solid var(--color-burgundy);
-  border-top: 2px solid var(--color-burgundy);
-  border-radius: var(--radius-lg) 0 0 0;
+.partial-badge {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  padding: 2px 7px;
+  background: var(--warning-soft);
+  border: 1px solid var(--warning);
+  border-radius: 5px;
+  color: var(--warning);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-/* Loading States */
+/* Web search indicators */
+.web-search-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  margin-bottom: 12px;
+  background: var(--info-soft);
+  border: 1px solid var(--info);
+  border-radius: var(--radius-pill);
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--info);
+}
+
+.web-search-error {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  margin-bottom: 12px;
+  background: var(--danger-soft);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-pill);
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--danger);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   STAGE RAIL CARD
+───────────────────────────────────────────────────────────────────────────── */
+.stage-rail-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px 18px;
+  margin-bottom: 26px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   STAGE SECTION HEADERS (council mode)
+───────────────────────────────────────────────────────────────────────────── */
+.stage-section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.stage-section-header--spaced {
+  margin-top: 18px;
+}
+
+.stage-tag {
+  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--fg-on-accent);
+  padding: 2px 7px;
+  border-radius: 5px;
+  letter-spacing: 0.03em;
+  flex: none;
+}
+
+.stage-tag--1 {
+  background: var(--seat-1);
+}
+
+.stage-tag--2 {
+  background: var(--seat-3);
+}
+
+.stage-tag--3 {
+  background: var(--accent);
+}
+
+.stage-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+
+.stage-status {
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+  margin-left: auto;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   ARENA RESOLUTION CARD
+───────────────────────────────────────────────────────────────────────────── */
+.arena-resolution-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 22px 24px;
+  margin-bottom: 22px;
+}
+
+.arena-resolution-header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 12px;
+}
+
+.arena-resolved-tag {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 3px 8px;
+  border-radius: 5px;
+}
+
+.arena-meta {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+}
+
+.arena-resolution-statement {
+  font-family: var(--font-head);
+  font-size: 23px;
+  font-weight: 600;
+  line-height: 1.22;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  margin: 0 0 18px 0;
+}
+
+.arena-participants {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.arena-participant-card {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 13px;
+  border: 1px solid;
+  border-radius: 10px;
+}
+
+.arena-participant-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.arena-participant-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.arena-participant-role {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.arena-vs {
+  width: 38px;
+  flex: none;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fg-faint);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   LOADING STATES
+───────────────────────────────────────────────────────────────────────────── */
 .loading-indicator {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
-  padding: var(--space-lg);
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  gap: 12px;
+  padding: 16px 0;
+  color: var(--fg-subtle);
+  font-size: 13.5px;
 }
 
 .stage-loading {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
-  padding: var(--space-md) var(--space-lg);
-  margin: var(--space-md) 0;
-  background: var(--color-ivory);
+  gap: 12px;
+  padding: 12px 16px;
+  margin: 12px 0;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
-  font-size: 0.8125rem;
-  font-style: italic;
+  color: var(--fg-subtle);
+  font-size: 13px;
+  font-family: var(--font-display);
 }
 
-/* Spinner - Elegant rotating ring */
+.stage-loading--streaming {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+}
+
+/* Spinner */
 .spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-burgundy);
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--line);
+  border-top-color: var(--accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
+  flex: none;
 }
 
 @keyframes spin {
@@ -259,425 +661,141 @@
   }
 }
 
-/* ============================================
-   Input Composer - Refined chat input
-   ============================================ */
-
-/* Fork Context Preview */
-.fork-context-preview {
-  margin: 0 var(--space-2xl);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-stage3);
-  border: 1px solid var(--color-stage3-border);
-  border-bottom: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  font-size: 0.8125rem;
-}
-
-.fork-context-header {
+/* Streaming display */
+.streaming-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-}
-
-.fork-context-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: var(--color-stage3-accent);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  font-weight: 600;
-}
-
-.fork-context-toggle:hover {
-  color: var(--color-text-primary);
-}
-
-.fork-context-dismiss {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: var(--space-xs);
-  cursor: pointer;
-  color: var(--color-text-muted);
-  border-radius: var(--radius-sm);
-}
-
-.fork-context-dismiss:hover {
-  background: var(--color-stage3-border);
-  color: var(--color-text-primary);
-}
-
-.fork-context-body {
-  margin-top: var(--space-sm);
-  padding-top: var(--space-sm);
-  border-top: 1px solid var(--color-stage3-border);
-}
-
-.fork-context-section {
-  margin-bottom: var(--space-sm);
-}
-
-.fork-context-label {
-  display: block;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-muted);
-  margin-bottom: 2px;
-}
-
-.fork-context-text {
-  margin: 0;
-  color: var(--color-text-primary);
-  line-height: 1.5;
-}
-
-.fork-context-synthesis {
-  max-height: 150px;
-  overflow-y: auto;
-  padding: var(--space-xs) var(--space-sm);
-  background: rgba(255, 255, 255, 0.5);
-  border-radius: var(--radius-sm);
-  font-size: 0.8125rem;
-}
-
-.fork-context-hint {
-  margin: 0;
-  font-size: 0.75rem;
-  font-style: italic;
-  color: var(--color-text-muted);
-}
-
-.input-form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  padding: var(--space-md) var(--space-2xl) var(--space-lg);
-  border-top: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
-}
-
-.message-input {
+  gap: 12px;
   width: 100%;
-  padding: var(--space-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-primary);
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  line-height: 1.6;
-  outline: none;
-  resize: vertical;
-  min-height: 100px;
-  max-height: 300px;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.message-input::placeholder {
-  color: var(--color-text-muted);
-  font-style: normal;
+.mono-count {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--fg);
 }
 
-.message-input:focus {
-  border-color: var(--color-burgundy);
-  box-shadow: 0 0 0 2px rgba(139, 38, 53, 0.1);
+.streaming-models {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  width: 100%;
 }
 
-.message-input:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  background: var(--color-parchment);
-}
-
-/* Input Controls - Compact toolbar */
-.input-controls {
+.streaming-model {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
-}
-
-.input-controls > *:last-child {
-  margin-left: auto;
-}
-
-.send-button {
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--color-burgundy);
-  border: none;
-  border-radius: var(--radius-md);
-  color: #fff;
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background var(--transition-fast), opacity var(--transition-fast), transform var(--transition-fast);
-  white-space: nowrap;
-}
-
-.send-button:hover:not(:disabled) {
-  background: var(--color-burgundy-dark);
-}
-
-.send-button:active:not(:disabled) {
-  transform: scale(0.98);
-}
-
-.send-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.cancel-button {
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--color-parchment);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
-  white-space: nowrap;
-}
-
-.cancel-button:hover {
-  background: var(--color-burgundy-light);
-  color: #fff;
-  border-color: var(--color-burgundy);
-}
-
-/* Web Search Toggle */
-.web-search-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  cursor: pointer;
-  font-size: 0.75rem;
-  color: var(--color-text-secondary);
-  user-select: none;
-  transition: color var(--transition-fast);
-  padding: var(--space-xs) var(--space-sm);
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  transition:
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.web-search-toggle:hover {
-  background: var(--color-ivory);
-  color: var(--color-text-primary);
+.streaming-model--active {
+  color: var(--accent);
 }
 
-.web-search-toggle input[type="checkbox"] {
-  width: 14px;
-  height: 14px;
-  cursor: pointer;
-  accent-color: var(--color-burgundy);
-}
-
-.web-search-toggle .toggle-label {
+.model-status {
+  font-size: 12px;
+  line-height: 1;
   display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
+}
+
+.streaming-model--active .model-status {
+  animation: ccPulse 0.8s ease-in-out infinite;
+}
+
+.model-name {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
 }
 
-.provider-badge {
-  font-size: 0.5625rem;
-  font-weight: 600;
-  padding: 1px 4px;
-  background: var(--color-parchment);
-  color: var(--color-text-muted);
+/* Token streaming preview */
+.streaming-preview {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
   border-radius: var(--radius-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-}
-
-/* Web Search Badge */
-.web-search-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-xs) var(--space-md);
-  margin-bottom: var(--space-md);
-  background: var(--color-stage1);
-  border: 1px solid var(--color-stage1-border);
-  border-radius: var(--radius-lg);
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  color: var(--color-stage1-accent);
-}
-
-.web-search-icon {
-  font-size: 0.875rem;
-}
-
-.web-search-error {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-xs) var(--space-md);
-  margin-bottom: var(--space-md);
-  background: var(--color-stage2);
-  border: 1px solid var(--color-stage2-border);
-  border-radius: var(--radius-lg);
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  color: var(--color-stage2-accent);
-}
-
-/* Mode Toggle - Segmented control */
-.mode-toggle {
-  display: flex;
-  gap: 0;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  line-height: 1.5;
+  max-height: 80px;
   overflow: hidden;
   position: relative;
 }
 
-/* Sliding background indicator */
-.mode-toggle::before {
+.preview-model {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-right: 8px;
+}
+
+.preview-text {
+  color: var(--fg-muted);
+}
+
+.cursor {
+  display: inline-block;
+  animation: cursorBlink 1s step-end infinite;
+  color: var(--accent);
+}
+
+@keyframes cursorBlink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.streaming-preview::after {
   content: '';
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: calc(50% - 3px);
-  height: calc(100% - 6px);
-  background: var(--color-burgundy);
-  border-radius: calc(var(--radius-md) - 3px);
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  z-index: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
+  background: linear-gradient(transparent, var(--surface));
+  pointer-events: none;
 }
 
-.mode-toggle.arena-mode::before {
-  transform: translateX(100%);
-}
-
-.mode-btn {
-  flex: 1;
-  padding: var(--space-sm) var(--space-md);
-  border: none;
-  background: transparent;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: color var(--transition-fast);
-  position: relative;
-  z-index: 1;
-}
-
-.mode-btn:hover:not(:disabled):not(.active) {
-  color: var(--color-text-primary);
-}
-
-.mode-btn.active {
-  color: #fff;
-}
-
-.mode-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* Arena Config */
-.arena-config {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  padding: var(--space-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-}
-
-.rounds-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-}
-
-.rounds-label span {
-  min-width: 100px;
-}
-
-.rounds-slider {
-  flex: 1;
-  height: 4px;
-  -webkit-appearance: none;
-  appearance: none;
-  background: var(--color-border);
-  border-radius: 2px;
-  outline: none;
-}
-
-.rounds-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 16px;
-  height: 16px;
-  background: var(--color-burgundy);
-  border-radius: 50%;
-  cursor: pointer;
-  transition: transform var(--transition-fast);
-}
-
-.rounds-slider::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
-}
-
-.rounds-slider::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
-  background: var(--color-burgundy);
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-}
-
-.rounds-hint {
-  font-family: var(--font-mono);
-  font-size: 0.625rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-}
-
-/* Interrupted Response Banner */
+/* ─────────────────────────────────────────────────────────────────────────────
+   INTERRUPTED BANNER
+───────────────────────────────────────────────────────────────────────────── */
 .interrupted-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-lg);
-  padding: var(--space-md) var(--space-lg);
-  margin-bottom: var(--space-lg);
-  background: linear-gradient(135deg, #FFF5F5 0%, #FFEBEB 100%);
-  border: 1px solid #F5C2C2;
-  border-radius: var(--radius-lg);
-  animation: slideDown 0.3s ease-out;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background: var(--danger-soft);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-md);
+  animation: slideDown var(--dur-standard) var(--ease-out);
 }
 
 @keyframes slideDown {
   from {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: translateY(-8px);
   }
   to {
     opacity: 1;
@@ -687,77 +805,49 @@
 
 .interrupted-content {
   display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  color: #C53030;
-}
-
-.interrupted-content svg {
-  flex-shrink: 0;
+  align-items: flex-start;
+  gap: 12px;
+  color: var(--danger);
+  min-width: 0;
 }
 
 .interrupted-text {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .interrupted-text strong {
-  font-size: 0.9375rem;
+  font-size: 14px;
   font-weight: 600;
-  color: #C53030;
+  color: var(--danger);
 }
 
 .interrupted-text span {
-  font-size: 0.8125rem;
-  color: #9B2C2C;
+  font-size: 13px;
+  color: var(--fg-muted);
 }
 
 .interrupted-actions {
   display: flex;
-  gap: var(--space-sm);
-  flex-shrink: 0;
+  gap: 6px;
+  flex: none;
 }
 
 .interrupted-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-md);
+  gap: 6px;
+  padding: 6px 12px;
   border: none;
-  border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-display);
+  font-size: 12.5px;
   font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition-fast), opacity var(--transition-fast);
-}
-
-.interrupted-btn.resume {
-  background: var(--color-stage3-accent);
-  color: white;
-}
-
-.interrupted-btn.resume:hover:not(:disabled) {
-  background: #3d6d4a;
-}
-
-.interrupted-btn.retry {
-  background: var(--color-burgundy);
-  color: white;
-}
-
-.interrupted-btn.retry:hover:not(:disabled) {
-  background: var(--color-burgundy-dark);
-}
-
-.interrupted-btn.dismiss {
-  background: var(--color-parchment);
-  color: var(--color-text-secondary);
-}
-
-.interrupted-btn.dismiss:hover:not(:disabled) {
-  background: #CBD5E0;
+  transition: opacity var(--dur-micro) var(--ease-out);
+  white-space: nowrap;
 }
 
 .interrupted-btn:disabled {
@@ -765,85 +855,165 @@
   cursor: not-allowed;
 }
 
-/* File Attachments */
-.file-input-hidden {
-  display: none;
+.interrupted-btn--resume {
+  background: var(--success);
+  color: var(--fg-on-accent);
 }
 
-.attach-btn {
+.interrupted-btn--resume:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.interrupted-btn--retry {
+  background: var(--accent);
+  color: var(--fg-on-accent);
+}
+
+.interrupted-btn--retry:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.interrupted-btn--dismiss {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  color: var(--fg-subtle);
+}
+
+.interrupted-btn--dismiss:hover {
+  background: var(--surface-hover);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   FORK CONTEXT PREVIEW
+───────────────────────────────────────────────────────────────────────────── */
+.fork-context-preview {
+  margin: 0 20px;
+  padding: 10px 14px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  font-size: 13px;
+}
+
+.fork-context-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.fork-context-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--accent);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.fork-context-toggle:hover {
+  color: var(--fg);
+}
+
+.fork-context-dismiss {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-sm);
-  background: var(--color-cream);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  padding: 4px;
   cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), opacity var(--transition-fast);
+  color: var(--fg-faint);
+  border-radius: var(--radius-sm);
 }
 
-.attach-btn:hover:not(:disabled) {
-  background: var(--color-ivory);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+.fork-context-dismiss:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
 }
 
-.attach-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.fork-context-body {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--accent);
 }
 
-.uploading-indicator {
-  margin-left: var(--space-xs);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+.fork-context-section {
+  margin-bottom: 8px;
 }
 
+.fork-context-label {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-faint);
+  margin-bottom: 3px;
+}
+
+.fork-context-text {
+  margin: 0;
+  color: var(--fg);
+  line-height: 1.5;
+}
+
+.fork-context-synthesis {
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 6px 10px;
+  background: var(--surface);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+}
+
+.fork-context-hint {
+  margin: 0;
+  font-size: 11.5px;
+  font-style: italic;
+  color: var(--fg-faint);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   ATTACHMENTS
+───────────────────────────────────────────────────────────────────────────── */
 .attachment-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-sm);
+  gap: 6px;
+  padding: 8px 14px 4px;
+}
+
+.attachment-chips--bar {
+  padding: 0 20px 8px;
 }
 
 .attachment-chip {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: 0.8125rem;
-  color: var(--color-text-primary);
-  animation: chipFadeIn 0.2s ease-out;
-  -webkit-backface-visibility: hidden;
-}
-
-@keyframes chipFadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-.attachment-chip svg {
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--fg);
 }
 
 .attachment-name {
-  max-width: 200px;
+  max-width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 11.5px;
 }
 
 .attachment-remove {
@@ -853,15 +1023,17 @@
   padding: 2px;
   background: transparent;
   border: none;
-  border-radius: var(--radius-sm);
-  color: var(--color-text-muted);
+  border-radius: 4px;
+  color: var(--fg-faint);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), opacity var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .attachment-remove:hover:not(:disabled) {
-  background: rgba(139, 38, 53, 0.1);
-  color: var(--color-burgundy);
+  background: var(--danger-soft);
+  color: var(--danger);
 }
 
 .attachment-remove:disabled {
@@ -869,292 +1041,259 @@
   cursor: not-allowed;
 }
 
-/* Council Progress Stepper */
-.council-progress {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-sm);
-  padding: var(--space-md) var(--space-lg);
-  margin-bottom: var(--space-md);
-  background: linear-gradient(135deg, var(--color-ivory) 0%, var(--color-parchment) 100%);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+/* ─────────────────────────────────────────────────────────────────────────────
+   BOTTOM ASK-BAR (conversation flow)
+───────────────────────────────────────────────────────────────────────────── */
+.ask-bar {
+  flex: none;
+  border-top: 1px solid var(--line);
+  padding: 10px 20px 14px;
+  background: var(--bg);
 }
 
-.progress-step {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
-  min-width: 70px;
+.ask-bar-inner {
+  max-width: 780px;
+  margin: 0 auto;
 }
 
-.step-indicator {
-  width: 32px;
-  height: 32px;
+.ask-bar-row {
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: var(--color-surface);
-  border: 2px solid var(--color-border);
+  gap: 8px;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  padding: 6px 8px 6px 12px;
+}
+
+.ask-bar-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+
+.ask-bar-input-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
+.ask-bar-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--fg);
+  line-height: 1.45;
+  resize: none;
+  min-height: 28px;
+  max-height: 120px;
+  display: block;
+}
+
+.ask-bar-input::placeholder {
+  color: var(--fg-faint);
+}
+
+.ask-bar-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ask-bar-send {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  flex: none;
+  transition: background var(--dur-micro) var(--ease-out);
+}
+
+.ask-bar-send:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.ask-bar-send:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.ask-bar-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ask-bar-cancel {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 14px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--fg-subtle);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  flex: none;
+  transition: background var(--dur-micro) var(--ease-out);
+}
+
+.ask-bar-cancel:hover {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   ARENA ROUND COUNT CONTROL
+───────────────────────────────────────────────────────────────────────────── */
+.arena-config {
+  padding: 8px 0 6px;
+}
+
+.rounds-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-subtle);
+  cursor: default;
+}
+
+.rounds-label-text {
+  flex: none;
+}
+
+.rounds-slider {
+  flex: 1;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--line);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+}
+
+.rounds-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  background: var(--accent);
   border-radius: 50%;
-  font-family: var(--font-mono);
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  transition: background var(--transition-medium), border-color var(--transition-medium), color var(--transition-medium), box-shadow var(--transition-medium);
+  cursor: pointer;
+  transition: transform var(--dur-micro) var(--ease-out);
 }
 
-.step-label {
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.rounds-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
 }
 
-.step-connector {
-  width: 40px;
-  height: 2px;
-  background: var(--color-border);
-  margin-bottom: var(--space-lg);
-  transition: background var(--transition-medium);
+.rounds-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  background: var(--accent);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
 }
 
-.progress-step.active .step-indicator {
-  background: var(--color-burgundy);
-  border-color: var(--color-burgundy);
-  color: white;
-  animation: pulse 1.5s ease-in-out infinite;
+.rounds-slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-.progress-step.active .step-label {
-  color: var(--color-burgundy);
-  font-weight: 600;
+/* ─────────────────────────────────────────────────────────────────────────────
+   FOCUS RINGS
+───────────────────────────────────────────────────────────────────────────── */
+.message-action-btn:focus-visible,
+.interrupted-btn:focus-visible,
+.ghost-chip:focus-visible,
+.convene-btn:focus-visible,
+.ask-bar-send:focus-visible,
+.ask-bar-cancel:focus-visible,
+.landing-prompt-chip:focus-visible,
+.fork-context-toggle:focus-visible,
+.fork-context-dismiss:focus-visible,
+.attachment-remove:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
 }
 
-.progress-step.complete .step-indicator {
-  background: var(--color-stage3-accent);
-  border-color: var(--color-stage3-accent);
-  color: white;
-}
-
-.progress-step.complete .step-label {
-  color: var(--color-stage3-accent);
-}
-
-.progress-step.complete + .step-connector {
-  background: var(--color-stage3-accent);
-}
-
-@keyframes pulse {
-  0%, 100% {
-    box-shadow: 0 0 0 0 rgba(139, 38, 53, 0.4);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(139, 38, 53, 0);
-  }
-}
-
-/* Message Actions Reveal Animation */
-.message-actions {
-  transform: translateX(8px);
-  transition:
-    opacity 0.2s ease,
-    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.message-group:hover .message-actions,
-.message-group:focus-within .message-actions {
-  transform: translateX(0);
-}
-
-.message-action-btn {
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease,
-    transform 0.15s ease;
-}
-
-.message-action-btn:hover {
-  transform: scale(1.05);
-}
-
-.message-action-btn:active {
-  transform: scale(0.95);
-}
-
-/* Responsive adjustments for input form */
+/* ─────────────────────────────────────────────────────────────────────────────
+   RESPONSIVE
+───────────────────────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
-  .input-form {
+  .landing-content {
+    padding: 40px 0 28px;
+  }
+
+  .landing-hero-h1 {
+    font-size: 30px;
+  }
+
+  .landing-hero-sub {
+    font-size: 14px;
+  }
+
+  .landing-seats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .messages-container {
+    padding: 64px 16px 24px; /* top offset for mobile menu toggle */
+  }
+
+  .ask-bar {
+    padding: 8px 12px 12px;
+  }
+
+  .ask-bar-row {
+    flex-wrap: wrap;
+    border-radius: var(--radius-md);
+  }
+
+  .arena-participants {
     flex-direction: column;
-    padding: var(--space-md);
   }
 
-  .input-controls {
-    width: 100%;
-    flex-direction: row;
-    justify-content: space-between;
+  .arena-vs {
+    width: auto;
   }
 
-  .mode-toggle {
-    width: 100%;
+  .interrupted-banner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
   }
 
-  .arena-config {
-    width: 100%;
-  }
-
-  .council-progress {
-    gap: var(--space-xs);
-    padding: var(--space-sm);
-  }
-
-  .progress-step {
-    min-width: 50px;
-  }
-
-  .step-indicator {
-    width: 28px;
-    height: 28px;
-    font-size: 0.75rem;
-  }
-
-  .step-label {
-    font-size: 0.5625rem;
-  }
-
-  .step-connector {
-    width: 20px;
+  .landing-scroll {
+    align-items: flex-start;
+    padding: 16px;
   }
 }
 
-/* ============================================
-   Streaming Progress Display
-   ============================================ */
+@media (prefers-reduced-motion: reduce) {
+  .message-group,
+  .interrupted-banner,
+  .spinner,
+  .cursor,
+  .streaming-model--active .model-status {
+    animation: none;
+  }
 
-.stage-loading.streaming {
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-md);
-  padding: var(--space-lg);
-  background: linear-gradient(135deg, var(--color-ivory) 0%, var(--color-parchment) 100%);
-}
-
-.streaming-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  width: 100%;
-}
-
-.streaming-header .spinner {
-  flex-shrink: 0;
-}
-
-.streaming-models {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-  width: 100%;
-}
-
-.streaming-model {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-  transition: border-color var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
-}
-
-.streaming-model.active {
-  border-color: var(--color-burgundy);
-  background: rgba(139, 38, 53, 0.05);
-  color: var(--color-burgundy);
-}
-
-.streaming-model.complete {
-  border-color: var(--color-stage3-accent);
-  background: rgba(72, 128, 85, 0.1);
-  color: var(--color-stage3-accent);
-}
-
-.model-status {
-  font-size: 0.875rem;
-  line-height: 1;
-}
-
-.streaming-model.active .model-status {
-  animation: blink 0.8s ease-in-out infinite;
-}
-
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
-.streaming-model .model-name {
-  max-width: 150px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Token streaming preview */
-.streaming-preview {
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-left: 3px solid var(--color-burgundy);
-  border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  line-height: 1.5;
-  max-height: 80px;
-  overflow: hidden;
-  position: relative;
-}
-
-.preview-model {
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  font-weight: 600;
-  color: var(--color-burgundy);
-  margin-right: var(--space-sm);
-}
-
-.preview-text {
-  color: var(--color-text-secondary);
-}
-
-.preview-text .cursor {
-  display: inline-block;
-  animation: cursorBlink 1s step-end infinite;
-  color: var(--color-burgundy);
-}
-
-@keyframes cursorBlink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0; }
-}
-
-/* Fade out at the bottom of preview */
-.streaming-preview::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 20px;
-  background: linear-gradient(transparent, var(--color-surface));
-  pointer-events: none;
+  .message-actions {
+    transition: none;
+  }
 }

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -18,6 +18,95 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   TOPBAR — persistent 56px header above the scroll area
+───────────────────────────────────────────────────────────────────────────── */
+.chat-topbar {
+  position: relative;
+  z-index: 2; /* above the dot-grid (z-index: 1 in the prototype) */
+  height: 56px;
+  flex: none;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 22px;
+}
+
+.chat-topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.chat-topbar-mode-badge {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 5px;
+  flex: none;
+}
+
+.chat-topbar-title {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: none;
+}
+
+/* Overlap stack: first avatar's -6px pull-back is compensated by padding-left */
+.chat-topbar-avatars {
+  display: flex;
+  align-items: center;
+  padding-left: 6px;
+  margin-right: 4px;
+}
+
+.chat-topbar-export {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
+}
+
+.chat-topbar-export:hover {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
+}
+
+.chat-topbar-export:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    LANDING STATE
 ───────────────────────────────────────────────────────────────────────────── */
 .landing-scroll {
@@ -1256,6 +1345,16 @@
    RESPONSIVE
 ───────────────────────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
+  /* Clear room for the fixed mobile-menu-toggle (~44px wide at left:--space-md) */
+  .chat-topbar {
+    padding: 0 22px 0 56px;
+  }
+
+  /* Badge doesn't fit alongside the toggle on narrow screens */
+  .chat-topbar-mode-badge {
+    display: none;
+  }
+
   .landing-content {
     padding: 40px 0 28px;
   }
@@ -1272,8 +1371,9 @@
     grid-template-columns: repeat(3, 1fr);
   }
 
+  /* Topbar now provides structural separation; revert the old toggle-offset */
   .messages-container {
-    padding: 64px 16px 24px; /* top offset for mobile menu toggle */
+    padding: 28px 16px 24px;
   }
 
   .ask-bar {

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -16,6 +16,7 @@ import {
   ChevronRight,
   Globe,
   ArrowRight,
+  Download,
 } from 'lucide-react';
 import { api } from '../api';
 import { getParticipantMapping, getMessageText, canRetryMessage } from '../lib/messageUtils';
@@ -27,6 +28,33 @@ import Round from './Round';
 import Synthesis from './Synthesis';
 import ModelErrors from './ModelErrors';
 import './ChatInterface.css';
+
+// Module-scope helpers + constants — pure, no component state, so they need not
+// be reallocated on every render.
+const modelShortName = (id) => id?.split('/')[1] || id || '';
+
+const councilStages = [
+  { label: 'First opinions', sublabel: 'stage 1' },
+  { label: 'Peer review', sublabel: 'stage 2' },
+  { label: 'Synthesis', sublabel: 'stage 3' },
+];
+const arenaStages = ['Opening', 'Rebuttal', 'Closing', 'Verdict'];
+
+function getCouncilCompleted(msg) {
+  const rounds = msg.rounds || [];
+  const hasResponses = rounds.some((r) => r.round_type === 'responses');
+  const hasRankings = rounds.some((r) => r.round_type === 'rankings');
+  return (hasResponses ? 1 : 0) + (hasRankings ? 1 : 0) + (msg.synthesis ? 1 : 0);
+}
+
+function getArenaCompleted(msg) {
+  const debateRounds = (msg.rounds || []).filter((r) => r.round_type !== 'synthesis');
+  if (msg.synthesis) return 4;
+  if (debateRounds.length >= 3) return 3;
+  if (debateRounds.length >= 2) return 2;
+  if (debateRounds.length >= 1) return 1;
+  return 0;
+}
 
 export default function ChatInterface({
   conversation,
@@ -42,6 +70,7 @@ export default function ChatInterface({
   onCancel,
   isLoading,
   isExtendingDebate,
+  onExportConversation,
 }) {
   const { data: config } = useConfig();
   const webSearchAvailable = config?.web_search_available;
@@ -167,24 +196,7 @@ export default function ChatInterface({
   };
 
   // ── helpers ────────────────────────────────────────────────────────────────
-  const modelShortName = (id) => id?.split('/')[1] || id || '';
   const chairShort = modelShortName(chairmanModel);
-
-  const getCouncilCompleted = (msg) => {
-    const rounds = msg.rounds || [];
-    const hasResponses = rounds.some((r) => r.round_type === 'responses');
-    const hasRankings = rounds.some((r) => r.round_type === 'rankings');
-    return (hasResponses ? 1 : 0) + (hasRankings ? 1 : 0) + (msg.synthesis ? 1 : 0);
-  };
-
-  const getArenaCompleted = (msg) => {
-    const debateRounds = (msg.rounds || []).filter((r) => r.round_type !== 'synthesis');
-    if (msg.synthesis) return 4;
-    if (debateRounds.length >= 3) return 3;
-    if (debateRounds.length >= 2) return 2;
-    if (debateRounds.length >= 1) return 1;
-    return 0;
-  };
 
   const hiddenFileInput = (
     <input
@@ -201,11 +213,63 @@ export default function ChatInterface({
   const showLanding =
     !conversation || (conversation.messages.length === 0 && !conversation.pendingInterrupted);
 
+  // ── Topbar — persistent across landing and conversation views ──────────────
+  const topBar = (
+    <header className="chat-topbar">
+      <div className="chat-topbar-left">
+        <span
+          className="chat-topbar-mode-badge"
+          style={
+            mode === 'arena'
+              ? { color: 'var(--accent)', background: 'var(--accent-soft)' }
+              : { color: 'var(--seat-1)', background: 'var(--seat-1-soft)' }
+          }
+        >
+          {mode === 'arena' ? 'ARENA' : 'COUNCIL'}
+        </span>
+        <span className="chat-topbar-title">{conversation?.title || 'New deliberation'}</span>
+      </div>
+      <div className="chat-topbar-right">
+        {councilModels.length > 0 && (
+          <div className="chat-topbar-avatars">
+            {councilModels.map((id) => {
+              const seat = seatOf(id);
+              const short = modelShortName(id);
+              return (
+                <SeatAvatar
+                  key={id}
+                  color={seat.color}
+                  initial={short[0]?.toUpperCase()}
+                  name={short}
+                  size={24}
+                  title={id}
+                  style={{ border: '2px solid var(--bg)', marginLeft: '-6px' }}
+                />
+              );
+            })}
+          </div>
+        )}
+        {conversation && (
+          <button
+            type="button"
+            className="chat-topbar-export"
+            onClick={() => onExportConversation?.(conversation.id, 'markdown')}
+            title="Export as Markdown"
+          >
+            <Download size={13} strokeWidth={2} aria-hidden="true" />
+            Export
+          </button>
+        )}
+      </div>
+    </header>
+  );
+
   // ── LANDING ────────────────────────────────────────────────────────────────
   if (showLanding) {
     return (
       <div className="chat-interface">
         {hiddenFileInput}
+        {topBar}
         <div className="landing-scroll">
           <div className="landing-content">
             {/* Status pill */}
@@ -409,16 +473,10 @@ export default function ChatInterface({
   }
 
   // ── CONVERSATION FLOW ──────────────────────────────────────────────────────
-  const councilStages = [
-    { label: 'First opinions', sublabel: 'stage 1' },
-    { label: 'Peer review', sublabel: 'stage 2' },
-    { label: 'Synthesis', sublabel: 'stage 3' },
-  ];
-  const arenaStages = ['Opening', 'Rebuttal', 'Closing', 'Verdict'];
-
   return (
     <div className="chat-interface">
       {hiddenFileInput}
+      {topBar}
 
       <div className="messages-container" ref={messagesContainerRef}>
         {/* Interrupted banner */}

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   Copy,
   Check,
-  RotateCcw,
+  RotateCw,
   AlertTriangle,
   X,
   Paperclip,
@@ -14,15 +14,15 @@ import {
   MessageSquarePlus,
   ChevronDown,
   ChevronRight,
+  Globe,
+  ArrowRight,
 } from 'lucide-react';
 import { api } from '../api';
-import {
-  getParticipantMapping,
-  getMessageText,
-  canRetryMessage,
-} from '../lib/messageUtils';
+import { getParticipantMapping, getMessageText, canRetryMessage } from '../lib/messageUtils';
 import { useUIStore } from '../stores/uiStore';
 import { useConfig } from '../hooks/queries';
+import { useSeatColors } from '../hooks/useSeatColors';
+import { SeatAvatar, StageRail } from './ui';
 import Round from './Round';
 import Synthesis from './Synthesis';
 import ModelErrors from './ModelErrors';
@@ -47,15 +47,19 @@ export default function ChatInterface({
   const webSearchAvailable = config?.web_search_available;
   const searchProvider = config?.search_provider || '';
   const arenaConfig = config?.arena || { default_rounds: 3, min_rounds: 2, max_rounds: 10 };
+  const councilModels = config?.council_models ?? [];
+  const chairmanModel = config?.chairman_model ?? '';
 
   const mode = useUIStore((s) => s.mode);
-  const setMode = useUIStore((s) => s.setMode);
   const useWebSearch = useUIStore((s) => s.useWebSearch);
   const toggleWebSearch = useUIStore((s) => s.toggleWebSearch);
   const arenaRoundCount = useUIStore((s) => s.arenaRoundCount);
   const setArenaRoundCount = useUIStore((s) => s.setArenaRoundCount);
   const pendingForkContext = useUIStore((s) => s.pendingForkContext);
   const setPendingForkContext = useUIStore((s) => s.setPendingForkContext);
+
+  const { seatOf } = useSeatColors();
+
   const [input, setInput] = useState('');
   const [copiedIndex, setCopiedIndex] = useState(null);
   const [attachments, setAttachments] = useState([]);
@@ -76,12 +80,10 @@ export default function ChatInterface({
     }
   };
 
-  const canRetry = (index) =>
-    canRetryMessage(conversation?.messages, index, isLoading);
+  const canRetry = (index) => canRetryMessage(conversation?.messages, index, isLoading);
 
   const handleRetry = () => {
     if (onRetry && conversation && conversation.messages.length >= 2) {
-      // Get the last user message
       const userMsgIndex = conversation.messages.length - 2;
       if (conversation.messages[userMsgIndex]?.role === 'user') {
         onRetry(conversation.messages[userMsgIndex].content);
@@ -95,12 +97,10 @@ export default function ChatInterface({
     }
   };
 
-  // Auto-scroll only when user hasn't scrolled away from bottom
   useEffect(() => {
     scrollToBottom();
   }, [conversation]);
 
-  // Reset auto-scroll when a new message is sent (user action)
   useEffect(() => {
     if (conversation?.messages?.length) {
       userHasScrolled.current = false;
@@ -108,17 +108,13 @@ export default function ChatInterface({
     }
   }, [conversation?.messages?.length]);
 
-  // Detect user scroll — pause auto-scroll if they've scrolled up
   useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
-
     const handleScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = container;
-      const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-      userHasScrolled.current = distanceFromBottom > 150;
+      userHasScrolled.current = scrollHeight - scrollTop - clientHeight > 150;
     };
-
     container.addEventListener('scroll', handleScroll, { passive: true });
     return () => container.removeEventListener('scroll', handleScroll);
   }, []);
@@ -126,7 +122,6 @@ export default function ChatInterface({
   const handleFileSelect = async (e) => {
     const files = Array.from(e.target.files || []);
     if (files.length === 0) return;
-
     setUploadingFile(true);
     try {
       for (const file of files) {
@@ -138,10 +133,7 @@ export default function ChatInterface({
       alert(error.message || 'Failed to upload file');
     } finally {
       setUploadingFile(false);
-      // Reset file input
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
-      }
+      if (fileInputRef.current) fileInputRef.current.value = '';
     }
   };
 
@@ -160,14 +152,10 @@ export default function ChatInterface({
 
   const handleKeyDown = (e) => {
     const isMod = e.metaKey || e.ctrlKey;
-
-    // Submit on Enter (without Shift) or Cmd/Ctrl+Enter
     if ((e.key === 'Enter' && !e.shiftKey) || (e.key === 'Enter' && isMod)) {
       e.preventDefault();
       handleSubmit(e);
     }
-
-    // Escape to cancel stream or clear input
     if (e.key === 'Escape') {
       if (isLoading || isExtendingDebate) {
         onCancel?.();
@@ -178,70 +166,310 @@ export default function ChatInterface({
     }
   };
 
-  if (!conversation) {
+  // ── helpers ────────────────────────────────────────────────────────────────
+  const modelShortName = (id) => id?.split('/')[1] || id || '';
+  const chairShort = modelShortName(chairmanModel);
+
+  const getCouncilCompleted = (msg) => {
+    const rounds = msg.rounds || [];
+    const hasResponses = rounds.some((r) => r.round_type === 'responses');
+    const hasRankings = rounds.some((r) => r.round_type === 'rankings');
+    return (hasResponses ? 1 : 0) + (hasRankings ? 1 : 0) + (msg.synthesis ? 1 : 0);
+  };
+
+  const getArenaCompleted = (msg) => {
+    const debateRounds = (msg.rounds || []).filter((r) => r.round_type !== 'synthesis');
+    if (msg.synthesis) return 4;
+    if (debateRounds.length >= 3) return 3;
+    if (debateRounds.length >= 2) return 2;
+    if (debateRounds.length >= 1) return 1;
+    return 0;
+  };
+
+  const hiddenFileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      className="file-input-hidden"
+      onChange={handleFileSelect}
+      disabled={isLoading || uploadingFile}
+      multiple
+      accept=".txt,.md,.json,.csv,.xml,.html,.py,.js,.ts,.pdf,.png,.jpg,.jpeg,.gif,.webp"
+    />
+  );
+
+  const showLanding =
+    !conversation || (conversation.messages.length === 0 && !conversation.pendingInterrupted);
+
+  // ── LANDING ────────────────────────────────────────────────────────────────
+  if (showLanding) {
     return (
       <div className="chat-interface">
-        <div className="empty-state">
-          <img src="/icon-source.png" alt="LLM Council" className="empty-state-icon" />
-          <h2>Welcome to LLM Council</h2>
-          <p>Create a new conversation to get started</p>
+        {hiddenFileInput}
+        <div className="landing-scroll">
+          <div className="landing-content">
+            {/* Status pill */}
+            <div className="landing-status-pill">
+              <span className="landing-status-dot" aria-hidden="true" />
+              <span className="landing-status-text">
+                {councilModels.length > 0
+                  ? `${councilModels.length} model${councilModels.length !== 1 ? 's' : ''} convened · ${chairShort || 'no chair'} chairing`
+                  : 'No models configured'}
+              </span>
+            </div>
+
+            {/* Hero */}
+            <h1 className="landing-hero-h1">
+              {mode === 'arena' ? (
+                <>
+                  Stage the debate
+                  <span className="landing-hero-faint">, not the prompt.</span>
+                </>
+              ) : (
+                <>
+                  Ask the council
+                  <span className="landing-hero-faint">, not a model.</span>
+                </>
+              )}
+            </h1>
+            <p className="landing-hero-sub">
+              {mode === 'arena'
+                ? 'Two models argue opposing sides across structured rounds. A chairman de-anonymizes and rules.'
+                : 'Your question goes to every model at once. They answer, rank each other blind, and a chairman synthesizes one accountable response.'}
+            </p>
+
+            {/* Seat cards */}
+            {councilModels.length > 0 && (
+              <div className="landing-seats">
+                {councilModels.map((modelId) => {
+                  const seat = seatOf(modelId);
+                  const shortName = modelShortName(modelId);
+                  const isChair = modelId === chairmanModel;
+                  return (
+                    <div key={modelId} className={`seat-card${isChair ? ' seat-card--chair' : ''}`}>
+                      <SeatAvatar
+                        color={seat.color}
+                        initial={shortName[0]?.toUpperCase()}
+                        name={shortName}
+                        size={30}
+                      />
+                      <span className="seat-card-name">{shortName}</span>
+                      <span className="seat-card-role">{isChair ? 'chairman' : 'member'}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Ask box */}
+            <form className="ask-box" onSubmit={handleSubmit}>
+              <textarea
+                className="ask-box-textarea"
+                placeholder={
+                  mode === 'arena'
+                    ? 'Is remote work better than office work for software teams?'
+                    : 'Is it worth rewriting our Go API gateway in Rust for throughput?'
+                }
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={isLoading || !conversation}
+                rows={2}
+              />
+              {attachments.length > 0 && (
+                <div className="attachment-chips">
+                  {attachments.map((att) => (
+                    <div key={att.id} className="attachment-chip">
+                      {att.file_type === 'image' ? <Image size={14} /> : <FileText size={14} />}
+                      <span className="attachment-name">{att.filename}</span>
+                      <button
+                        type="button"
+                        className="attachment-remove"
+                        onClick={() => handleRemoveAttachment(att.id)}
+                        disabled={isLoading}
+                        aria-label={`Remove ${att.filename}`}
+                      >
+                        <X size={12} aria-hidden="true" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="ask-box-toolbar">
+                <div className="ask-box-chips">
+                  {webSearchAvailable && (
+                    <button
+                      type="button"
+                      className={`ghost-chip${useWebSearch ? ' ghost-chip--active' : ''}`}
+                      onClick={toggleWebSearch}
+                      disabled={isLoading}
+                      title={`Search via ${searchProvider === 'tavily' ? 'Tavily' : 'DuckDuckGo'}`}
+                    >
+                      <Globe size={13} strokeWidth={2} aria-hidden="true" />
+                      web search
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="ghost-chip"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isLoading || uploadingFile}
+                  >
+                    <Paperclip size={13} strokeWidth={2} aria-hidden="true" />
+                    {uploadingFile ? 'uploading…' : 'attach'}
+                  </button>
+                </div>
+                {isLoading || isExtendingDebate ? (
+                  <button type="button" className="ask-bar-cancel" onClick={onCancel}>
+                    Cancel
+                  </button>
+                ) : (
+                  <button
+                    type="submit"
+                    className="convene-btn"
+                    disabled={!input.trim() || !conversation}
+                  >
+                    {mode === 'arena' ? 'Open debate' : 'Convene council'}
+                    <ArrowRight size={14} strokeWidth={2} aria-hidden="true" />
+                  </button>
+                )}
+              </div>
+            </form>
+
+            {/* Prompt chips */}
+            <div className="landing-prompt-chips">
+              {mode === 'arena' ? (
+                <>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() =>
+                      setInput('Is remote work better than office work for software teams?')
+                    }
+                  >
+                    Remote vs Office
+                  </button>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() => setInput('Should AI development be regulated by governments?')}
+                  >
+                    AI Regulation
+                  </button>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() =>
+                      setInput('Is social media a net positive or negative for society?')
+                    }
+                  >
+                    Social Media Impact
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() =>
+                      setInput(
+                        'What are the trade-offs between monolith and microservices architectures?'
+                      )
+                    }
+                  >
+                    Architecture Decisions
+                  </button>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() =>
+                      setInput(
+                        'How should I approach learning a new programming language effectively?'
+                      )
+                    }
+                  >
+                    Learning Strategies
+                  </button>
+                  <button
+                    type="button"
+                    className="landing-prompt-chip"
+                    onClick={() =>
+                      setInput('What factors should I consider when choosing between job offers?')
+                    }
+                  >
+                    Career Advice
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     );
   }
 
+  // ── CONVERSATION FLOW ──────────────────────────────────────────────────────
+  const councilStages = [
+    { label: 'First opinions', sublabel: 'stage 1' },
+    { label: 'Peer review', sublabel: 'stage 2' },
+    { label: 'Synthesis', sublabel: 'stage 3' },
+  ];
+  const arenaStages = ['Opening', 'Rebuttal', 'Closing', 'Verdict'];
+
   return (
     <div className="chat-interface">
+      {hiddenFileInput}
+
       <div className="messages-container" ref={messagesContainerRef}>
-        {/* Interrupted Response Banner */}
+        {/* Interrupted banner */}
         {conversation.pendingInterrupted &&
           conversation.pendingInfo &&
           (() => {
             const hasStage1 =
-              (conversation.pendingInfo.partial_data?.responses?.length > 0) ||
-              (conversation.pendingInfo.partial_data?.stage1?.length > 0);
+              conversation.pendingInfo.partial_data?.responses?.length > 0 ||
+              conversation.pendingInfo.partial_data?.stage1?.length > 0;
             const canResume = hasStage1 && conversation.pendingInfo.mode === 'council';
             return (
               <div className="interrupted-banner">
                 <div className="interrupted-content">
-                  <AlertTriangle size={20} />
+                  <AlertTriangle size={16} aria-hidden="true" />
                   <div className="interrupted-text">
-                    <strong>Response was interrupted</strong>
+                    <strong>Response interrupted</strong>
                     <span>
                       {conversation.pendingInfo.mode === 'arena'
                         ? 'Arena debate'
                         : 'Council response'}{' '}
                       was interrupted.
                       {canResume
-                        ? ' Stage 1 completed - you can resume from Stage 2.'
-                        : ' Would you like to retry?'}
+                        ? ' Stage 1 completed — resume from Stage 2?'
+                        : ' Retry the full request?'}
                     </span>
                   </div>
                 </div>
                 <div className="interrupted-actions">
                   {canResume && (
                     <button
-                      className="interrupted-btn resume"
+                      className="interrupted-btn interrupted-btn--resume"
                       onClick={() => onRetryInterrupted(true)}
                       disabled={isLoading}
                     >
-                      <Play size={14} />
+                      <Play size={13} aria-hidden="true" />
                       Resume
                     </button>
                   )}
                   <button
-                    className="interrupted-btn retry"
+                    className="interrupted-btn interrupted-btn--retry"
                     onClick={() => onRetryInterrupted(false)}
                     disabled={isLoading}
                   >
-                    <RotateCcw size={14} />
+                    <RotateCw size={13} aria-hidden="true" />
                     Retry
                   </button>
                   <button
-                    className="interrupted-btn dismiss"
+                    className="interrupted-btn interrupted-btn--dismiss"
                     onClick={onDismissInterrupted}
                   >
-                    <X size={14} />
+                    <X size={13} aria-hidden="true" />
                     Dismiss
                   </button>
                 </div>
@@ -249,349 +477,381 @@ export default function ChatInterface({
             );
           })()}
 
-        {conversation.messages.length === 0 && !conversation.pendingInterrupted ? (
-          <div className="empty-state">
-            <img src="/icon-source.png" alt="LLM Council" className="empty-state-icon" />
-            <h2>{mode === 'arena' ? 'Start a Debate' : 'Consult the Council'}</h2>
-            <p>
-              {mode === 'arena'
-                ? 'Watch AI models debate and deliberate on controversial topics.'
-                : 'Get synthesized answers from multiple AI models with peer review.'}
-            </p>
-            <div className="prompt-suggestions">
-              <span className="suggestions-label">Try asking about:</span>
-              <div className="prompt-chips">
-                {mode === 'arena' ? (
-                  <>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() =>
-                        setInput('Is remote work better than office work for software teams?')
-                      }
-                    >
-                      Remote vs Office
-                    </button>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() => setInput('Should AI development be regulated by governments?')}
-                    >
-                      AI Regulation
-                    </button>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() =>
-                        setInput('Is social media a net positive or negative for society?')
-                      }
-                    >
-                      Social Media Impact
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() =>
-                        setInput(
-                          'What are the trade-offs between monolith and microservices architectures?'
-                        )
-                      }
-                    >
-                      Architecture Decisions
-                    </button>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() =>
-                        setInput(
-                          'How should I approach learning a new programming language effectively?'
-                        )
-                      }
-                    >
-                      Learning Strategies
-                    </button>
-                    <button
-                      type="button"
-                      className="prompt-chip"
-                      onClick={() =>
-                        setInput('What factors should I consider when choosing between job offers?')
-                      }
-                    >
-                      Career Advice
-                    </button>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        ) : (
-          conversation.messages.map((msg, index) => (
-            <div key={index} className="message-group">
-              {msg.role === 'user' ? (
-                <div className="user-message">
-                  <div className="message-header">
-                    <div className="message-label">You</div>
-                    <div className="message-actions">
-                      <button
-                        className="message-action-btn"
-                        onClick={() => handleCopy(msg.content, index)}
-                        aria-label={copiedIndex === index ? 'Copied' : 'Copy message'}
-                      >
-                        {copiedIndex === index ? (
-                          <Check size={14} aria-hidden="true" />
-                        ) : (
-                          <Copy size={14} aria-hidden="true" />
-                        )}
-                      </button>
-                    </div>
+        {/* Messages */}
+        {conversation.messages.map((msg, index) => (
+          <div key={index} className="message-group">
+            {msg.role === 'user' ? (
+              <div className="user-message">
+                <span className="user-badge" aria-label="You">
+                  you
+                </span>
+                <div className="user-message-body">
+                  <div className="markdown-content">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
                   </div>
-                  <div className="message-content">
-                    <div className="markdown-content">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
-                    </div>
+                  <div className="message-actions">
+                    <button
+                      className="message-action-btn"
+                      onClick={() => handleCopy(msg.content, index)}
+                      aria-label={copiedIndex === index ? 'Copied' : 'Copy message'}
+                    >
+                      {copiedIndex === index ? (
+                        <Check size={13} aria-hidden="true" />
+                      ) : (
+                        <Copy size={13} aria-hidden="true" />
+                      )}
+                    </button>
                   </div>
                 </div>
-              ) : (
-                <div className={`assistant-message ${msg.partial ? 'partial-response' : ''}`}>
-                  <div className="message-header">
-                    <div className="message-label">
-                      {msg.mode === 'arena' ? 'Arena Debate' : 'LLM Council'}
-                      {msg.partial && <span className="partial-badge">Partial</span>}
-                    </div>
-                    <div className="message-actions">
-                      {getMessageText(msg) && (
-                        <button
-                          className="message-action-btn"
-                          onClick={() => handleCopy(getMessageText(msg), index)}
-                          aria-label={copiedIndex === index ? 'Copied' : 'Copy final answer'}
-                        >
-                          {copiedIndex === index ? (
-                            <Check size={14} aria-hidden="true" />
-                          ) : (
-                            <Copy size={14} aria-hidden="true" />
-                          )}
-                        </button>
-                      )}
-                      {canRetry(index) && (
-                        <button
-                          className="message-action-btn retry-btn"
-                          onClick={handleRetry}
-                          aria-label="Retry this question"
-                        >
-                          <RotateCcw size={14} aria-hidden="true" />
-                        </button>
-                      )}
-                    </div>
+              </div>
+            ) : (
+              <div className={`assistant-message${msg.partial ? ' partial-response' : ''}`}>
+                {msg.partial && (
+                  <div className="partial-badge-row">
+                    <span className="partial-badge">Partial</span>
                   </div>
+                )}
 
-                  {/* Web Search */}
-                  {msg.loading?.webSearch && (
-                    <div className="stage-loading" role="status" aria-live="polite">
-                      <div className="spinner" aria-hidden="true"></div>
-                      <span>Searching the web...</span>
-                    </div>
-                  )}
-                  {msg.webSearchUsed && (
-                    <div className="web-search-badge">
-                      <span className="web-search-icon">🔍</span> Web search results included
-                    </div>
-                  )}
-                  {msg.webSearchError && !msg.webSearchUsed && (
-                    <div className="web-search-error">
-                      <span className="web-search-icon">⚠️</span> {msg.webSearchError}
-                    </div>
-                  )}
+                <div className="message-header">
+                  <span className="message-label">
+                    {msg.mode === 'arena' ? 'Arena Debate' : 'LLM Council'}
+                  </span>
+                  <div className="message-actions">
+                    {getMessageText(msg) && (
+                      <button
+                        className="message-action-btn"
+                        onClick={() => handleCopy(getMessageText(msg), index)}
+                        aria-label={copiedIndex === index ? 'Copied' : 'Copy final answer'}
+                      >
+                        {copiedIndex === index ? (
+                          <Check size={13} aria-hidden="true" />
+                        ) : (
+                          <Copy size={13} aria-hidden="true" />
+                        )}
+                      </button>
+                    )}
+                    {canRetry(index) && (
+                      <button
+                        className="message-action-btn"
+                        onClick={handleRetry}
+                        aria-label="Retry this question"
+                      >
+                        <RotateCw size={13} aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                </div>
 
-                  {msg.errors?.length > 0 && (
-                    <ModelErrors
-                      errors={msg.errors}
-                      onRetry={
-                        !isLoading && onRetryAll
-                          ? () => onRetryAll(conversation.id)
-                          : undefined
-                      }
-                    />
-                  )}
+                {/* Web search states */}
+                {msg.loading?.webSearch && (
+                  <div className="stage-loading" role="status" aria-live="polite">
+                    <div className="spinner" aria-hidden="true" />
+                    <span>Searching the web…</span>
+                  </div>
+                )}
+                {msg.webSearchUsed && (
+                  <div className="web-search-badge">
+                    <Globe size={12} aria-hidden="true" />
+                    Web search results included
+                  </div>
+                )}
+                {msg.webSearchError && !msg.webSearchUsed && (
+                  <div className="web-search-error">
+                    <AlertTriangle size={12} aria-hidden="true" />
+                    {msg.webSearchError}
+                  </div>
+                )}
 
-                  {/* Unified Round Display - Works for both Arena and Council modes */}
-                  {(() => {
-                    const isArena = msg.mode === 'arena';
-                    const rounds = msg.rounds || [];
-                    const synthesis = msg.synthesis;
-                    const participantMapping = getParticipantMapping(msg);
-                    const mode = isArena ? 'arena' : 'council';
+                {msg.errors?.length > 0 && (
+                  <ModelErrors
+                    errors={msg.errors}
+                    onRetry={
+                      !isLoading && onRetryAll ? () => onRetryAll(conversation.id) : undefined
+                    }
+                  />
+                )}
 
-                    return (
-                      <>
-                        {/* Progress Stepper for Council mode */}
-                        {!isArena &&
-                          (msg.loading?.round ||
-                            msg.loading?.synthesis ||
-                            rounds.length > 0) && (
-                            <div
-                              className="council-progress"
-                              role="progressbar"
-                              aria-label="Council deliberation progress"
-                            >
-                              {(() => {
-                                const hasResponses = rounds.some(r => r.round_type === 'responses');
-                                const hasRankings = rounds.some(r => r.round_type === 'rankings');
-                                const loadingResponses = msg.loading?.round && msg.loading?.roundType === 'responses';
-                                const loadingRankings = msg.loading?.round && msg.loading?.roundType === 'rankings';
-                                const loadingSynthesis = msg.loading?.synthesis;
-                                return (
-                                  <>
-                                    <div className={`progress-step ${hasResponses ? 'complete' : ''} ${loadingResponses ? 'active' : ''}`}>
-                                      <div className="step-indicator">{hasResponses ? '✓' : '1'}</div>
-                                      <span className="step-label">Responses</span>
-                                    </div>
-                                    <div className="step-connector"></div>
-                                    <div className={`progress-step ${hasRankings ? 'complete' : ''} ${loadingRankings ? 'active' : ''}`}>
-                                      <div className="step-indicator">{hasRankings ? '✓' : '2'}</div>
-                                      <span className="step-label">Rankings</span>
-                                    </div>
-                                    <div className="step-connector"></div>
-                                    <div className={`progress-step ${synthesis ? 'complete' : ''} ${loadingSynthesis ? 'active' : ''}`}>
-                                      <div className="step-indicator">{synthesis ? '✓' : '3'}</div>
-                                      <span className="step-label">Synthesis</span>
-                                    </div>
-                                  </>
-                                );
-                              })()}
+                {(() => {
+                  const isArena = msg.mode === 'arena';
+                  const rounds = msg.rounds || [];
+                  const synthesis = msg.synthesis;
+                  const participantMapping = getParticipantMapping(msg);
+                  const msgMode = isArena ? 'arena' : 'council';
+
+                  const hasResponsesRound = rounds.some((r) => r.round_type === 'responses');
+                  const showCouncilRail =
+                    !isArena && (msg.loading?.round || msg.loading?.synthesis || rounds.length > 0);
+
+                  return (
+                    <>
+                      {/* Council: stage rail */}
+                      {showCouncilRail && (
+                        <div className="stage-rail-card">
+                          <StageRail
+                            stages={councilStages}
+                            completedCount={getCouncilCompleted(msg)}
+                          />
+                        </div>
+                      )}
+
+                      {/* Arena: resolution card + round rail */}
+                      {isArena && (rounds.length > 0 || synthesis) && (
+                        <>
+                          <div className="arena-resolution-card">
+                            <div className="arena-resolution-header">
+                              <span className="arena-resolved-tag">RESOLVED</span>
+                              <span className="arena-meta">
+                                {arenaRoundCount} round{arenaRoundCount !== 1 ? 's' : ''} ·{' '}
+                                {participantMapping ? Object.keys(participantMapping).length : 2}{' '}
+                                participants
+                              </span>
                             </div>
-                          )}
-
-                        {/* Loading states */}
-                        {msg.loading?.round && msg.loading?.roundType === 'responses' && (
-                          <div className="stage-loading streaming" role="status" aria-live="polite">
-                            {msg.streaming?.progress ? (
-                              <>
-                                <div className="streaming-header">
-                                  <div className="spinner" aria-hidden="true"></div>
-                                  <span>
-                                    Collecting responses: {msg.streaming.progress.completed} of{' '}
-                                    {msg.streaming.progress.total}
-                                  </span>
-                                </div>
-                                <div className="streaming-models">
-                                  {msg.streaming.models?.map((model) => {
-                                    const modelShort = model.split('/')[1] || model;
-                                    const isComplete = msg.streaming.progress.completed_models?.includes(model);
-                                    const isStreaming = msg.streaming.tokens?.[model];
+                            {conversation.messages[index - 1]?.content && (
+                              <h2 className="arena-resolution-statement">
+                                {conversation.messages[index - 1].content}
+                              </h2>
+                            )}
+                            {participantMapping && Object.keys(participantMapping).length >= 2 && (
+                              <div className="arena-participants">
+                                {Object.entries(participantMapping)
+                                  .slice(0, 2)
+                                  .map(([label, modelId], pIdx) => {
+                                    const pSeat = seatOf(modelId);
+                                    const pShort = modelShortName(modelId);
                                     return (
-                                      <div
-                                        key={model}
-                                        className={`streaming-model ${isComplete ? 'complete' : ''} ${isStreaming ? 'active' : ''}`}
-                                      >
-                                        <span className="model-status">
-                                          {isComplete ? '✓' : isStreaming ? '⋯' : '○'}
-                                        </span>
-                                        <span className="model-name">{modelShort}</span>
-                                      </div>
+                                      <Fragment key={label}>
+                                        {pIdx === 1 && (
+                                          <span className="arena-vs" aria-hidden="true">
+                                            vs
+                                          </span>
+                                        )}
+                                        <div
+                                          className="arena-participant-card"
+                                          style={{
+                                            background: pSeat.soft,
+                                            borderColor: pSeat.color,
+                                          }}
+                                        >
+                                          <SeatAvatar
+                                            color={pSeat.color}
+                                            initial={pShort[0]?.toUpperCase()}
+                                            name={pShort}
+                                            size={26}
+                                          />
+                                          <div className="arena-participant-info">
+                                            <span className="arena-participant-name">{pShort}</span>
+                                            <span
+                                              className="arena-participant-role"
+                                              style={{ color: pSeat.color }}
+                                            >
+                                              {pIdx === 0 ? 'ARGUING FOR' : 'ARGUING AGAINST'}
+                                            </span>
+                                          </div>
+                                        </div>
+                                      </Fragment>
                                     );
                                   })}
-                                </div>
-                                {/* Show streaming token preview for currently active models */}
-                                {Object.entries(msg.streaming.tokens || {}).map(([model, tokens]) => (
-                                  <div key={model} className="streaming-preview">
-                                    <span className="preview-model">{model.split('/')[1] || model}:</span>
-                                    <span className="preview-text">
-                                      {tokens.slice(-100)}
-                                      <span className="cursor">▋</span>
-                                    </span>
-                                  </div>
-                                ))}
-                              </>
-                            ) : (
-                              <>
-                                <div className="spinner" aria-hidden="true"></div>
-                                <span>Collecting individual responses...</span>
-                              </>
+                              </div>
                             )}
                           </div>
-                        )}
-                        {msg.loading?.round && msg.loading?.roundType === 'rankings' && (
-                          <div className="stage-loading" role="status" aria-live="polite">
-                            <div className="spinner" aria-hidden="true"></div>
-                            <span>Peer rankings in progress...</span>
+
+                          <div className="stage-rail-card">
+                            <StageRail
+                              stages={arenaStages}
+                              completedCount={getArenaCompleted(msg)}
+                            />
                           </div>
-                        )}
-                        {msg.loading?.round && !['responses', 'rankings'].includes(msg.loading?.roundType) && (
+                        </>
+                      )}
+
+                      {/* Loading: responses */}
+                      {msg.loading?.round && msg.loading?.roundType === 'responses' && (
+                        <div
+                          className="stage-loading stage-loading--streaming"
+                          role="status"
+                          aria-live="polite"
+                        >
+                          {msg.streaming?.progress ? (
+                            <>
+                              <div className="streaming-header">
+                                <div className="spinner" aria-hidden="true" />
+                                <span>
+                                  Collecting responses:{' '}
+                                  <span className="mono-count">
+                                    {msg.streaming.progress.completed} /{' '}
+                                    {msg.streaming.progress.total}
+                                  </span>
+                                </span>
+                              </div>
+                              <div className="streaming-models">
+                                {msg.streaming.models?.map((model) => {
+                                  const mShort = model.split('/')[1] || model;
+                                  const isComplete =
+                                    msg.streaming.progress.completed_models?.includes(model);
+                                  const isStreaming = msg.streaming.tokens?.[model];
+                                  const mSeat = seatOf(model);
+                                  return (
+                                    <div
+                                      key={model}
+                                      className={`streaming-model${isComplete ? ' streaming-model--complete' : ''}${isStreaming ? ' streaming-model--active' : ''}`}
+                                      style={
+                                        isComplete
+                                          ? { borderColor: mSeat.color, color: mSeat.color }
+                                          : isStreaming
+                                            ? { borderColor: mSeat.color }
+                                            : {}
+                                      }
+                                    >
+                                      <span className="model-status">
+                                        {isComplete ? (
+                                          <Check size={10} strokeWidth={3} />
+                                        ) : isStreaming ? (
+                                          '·'
+                                        ) : (
+                                          '○'
+                                        )}
+                                      </span>
+                                      <span className="model-name">{mShort}</span>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                              {Object.entries(msg.streaming.tokens || {}).map(([model, tokens]) => (
+                                <div key={model} className="streaming-preview">
+                                  <span className="preview-model">
+                                    {model.split('/')[1] || model}:
+                                  </span>
+                                  <span className="preview-text">
+                                    {tokens.slice(-100)}
+                                    <span className="cursor" aria-hidden="true">
+                                      ▋
+                                    </span>
+                                  </span>
+                                </div>
+                              ))}
+                            </>
+                          ) : (
+                            <>
+                              <div className="spinner" aria-hidden="true" />
+                              <span>Collecting individual responses…</span>
+                            </>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Loading: rankings */}
+                      {msg.loading?.round && msg.loading?.roundType === 'rankings' && (
+                        <div className="stage-loading" role="status" aria-live="polite">
+                          <div className="spinner" aria-hidden="true" />
+                          <span>Peer rankings in progress…</span>
+                        </div>
+                      )}
+
+                      {/* Loading: arena rounds */}
+                      {msg.loading?.round &&
+                        !['responses', 'rankings'].includes(msg.loading?.roundType) && (
                           <div className="stage-loading" role="status" aria-live="polite">
-                            <div className="spinner" aria-hidden="true"></div>
+                            <div className="spinner" aria-hidden="true" />
                             <span>
                               {msg.loading.roundType === 'initial'
-                                ? 'Collecting initial positions...'
-                                : `Round ${msg.loading.roundNumber}: Deliberating...`}
+                                ? 'Collecting initial positions…'
+                                : `Round ${msg.loading.roundNumber}: Deliberating…`}
                             </span>
                           </div>
                         )}
 
-                        {/* Render rounds using unified Round component */}
-                        {rounds.map((round, i) => (
+                      {/* Council Stage 1 header */}
+                      {!isArena && hasResponsesRound && (
+                        <div className="stage-section-header">
+                          <span className="stage-tag stage-tag--1">STAGE 1</span>
+                          <h3 className="stage-title">First opinions</h3>
+                          <span className="stage-status">
+                            {rounds.find((r) => r.round_type === 'responses')?.responses?.length ??
+                              '?'}{' '}
+                            / {councilModels.length} responded
+                          </span>
+                        </div>
+                      )}
+
+                      {/* Rounds */}
+                      {rounds.map((round, i) => (
+                        <Fragment key={`${round.round_type}-${round.round_number ?? i}`}>
+                          {/* Council Stage 2 header — injected before rankings round */}
+                          {!isArena && round.round_type === 'rankings' && (
+                            <div className="stage-section-header stage-section-header--spaced">
+                              <span className="stage-tag stage-tag--2">STAGE 2</span>
+                              <h3 className="stage-title">Peer review</h3>
+                              <span className="stage-status">blind · anonymized</span>
+                            </div>
+                          )}
                           <Round
-                            key={`${round.round_type}-${round.round_number || i}`}
                             round={round}
                             participantMapping={participantMapping}
                             isCollapsible={isArena}
                             defaultCollapsed={false}
                             showMetrics={false}
                           />
-                        ))}
+                        </Fragment>
+                      ))}
 
-                        {/* Synthesis loading */}
-                        {msg.loading?.synthesis && (
-                          <div className="stage-loading" role="status" aria-live="polite">
-                            <div className="spinner" aria-hidden="true"></div>
-                            <span>
-                              {isArena
-                                ? 'Synthesizing debate outcomes...'
-                                : 'Final synthesis in progress...'}
-                            </span>
-                          </div>
-                        )}
+                      {/* Loading: synthesis */}
+                      {msg.loading?.synthesis && (
+                        <div className="stage-loading" role="status" aria-live="polite">
+                          <div className="spinner" aria-hidden="true" />
+                          <span>
+                            {isArena
+                              ? 'Synthesizing debate outcomes…'
+                              : 'Final synthesis in progress…'}
+                          </span>
+                        </div>
+                      )}
 
-                        {/* Render synthesis using unified Synthesis component */}
-                        {synthesis && (
-                          <Synthesis
-                            synthesis={synthesis}
-                            participantMapping={participantMapping}
-                            originalQuestion={conversation?.messages[index - 1]?.content}
-                            conversationId={conversation?.id}
-                            onForkConversation={onForkConversation}
-                            onExtendDebate={isArena ? onExtendDebate : undefined}
-                            onRetrySynthesis={!isArena ? onRetrySynthesis : undefined}
-                            isExtending={isExtendingDebate}
-                            isLoading={isLoading}
-                            mode={mode}
-                          />
-                        )}
-                      </>
-                    );
-                  })()}
-                </div>
-              )}
-            </div>
-          ))
-        )}
+                      {/* Council Stage 3 header + Synthesis */}
+                      {synthesis && !isArena && (
+                        <div className="stage-section-header stage-section-header--spaced">
+                          <span className="stage-tag stage-tag--3">STAGE 3</span>
+                          <h3 className="stage-title">Synthesis</h3>
+                          <span className="stage-status">chairman · {chairShort}</span>
+                        </div>
+                      )}
 
-        {isLoading && (() => {
-          const last = conversation.messages[conversation.messages.length - 1];
-          const hasStageLoading = last?.loading?.round || last?.loading?.synthesis;
-          return !hasStageLoading;
-        })() && (
-          <div className="loading-indicator">
-            <div className="spinner"></div>
-            <span>Consulting the council...</span>
+                      {synthesis && (
+                        <Synthesis
+                          synthesis={synthesis}
+                          participantMapping={participantMapping}
+                          originalQuestion={conversation?.messages[index - 1]?.content}
+                          conversationId={conversation?.id}
+                          onForkConversation={onForkConversation}
+                          onExtendDebate={isArena ? onExtendDebate : undefined}
+                          onRetrySynthesis={!isArena ? onRetrySynthesis : undefined}
+                          isExtending={isExtendingDebate}
+                          isLoading={isLoading}
+                          mode={msgMode}
+                        />
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
+            )}
           </div>
-        )}
+        ))}
+
+        {isLoading &&
+          (() => {
+            const last = conversation.messages[conversation.messages.length - 1];
+            return !(last?.loading?.round || last?.loading?.synthesis);
+          })() && (
+            <div className="loading-indicator">
+              <div className="spinner" aria-hidden="true" />
+              <span>Consulting the council…</span>
+            </div>
+          )}
 
         <div ref={messagesEndRef} />
       </div>
 
+      {/* Fork context preview */}
       {pendingForkContext && (
         <div className="fork-context-preview">
           <div className="fork-context-header">
@@ -601,8 +861,8 @@ export default function ChatInterface({
               onClick={() => setForkContextExpanded(!forkContextExpanded)}
               aria-expanded={forkContextExpanded}
             >
-              {forkContextExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-              <MessageSquarePlus size={16} />
+              {forkContextExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <MessageSquarePlus size={14} />
               <span>Continuing from previous discussion</span>
             </button>
             <button
@@ -611,7 +871,7 @@ export default function ChatInterface({
               onClick={() => setPendingForkContext(null)}
               aria-label="Dismiss context"
             >
-              <X size={14} />
+              <X size={13} />
             </button>
           </div>
           {forkContextExpanded && (
@@ -636,146 +896,104 @@ export default function ChatInterface({
         </div>
       )}
 
-      <form className="input-form" onSubmit={handleSubmit}>
-        <textarea
-          className="message-input"
-          placeholder="Ask your question... (Shift+Enter for new line, Enter to send)"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={isLoading}
-          rows={3}
-        />
-
-        {/* Mode Toggle */}
-        <div
-          className={`mode-toggle ${mode === 'arena' ? 'arena-mode' : ''}`}
-          role="radiogroup"
-          aria-label="Response mode"
-        >
-          <button
-            type="button"
-            role="radio"
-            aria-checked={mode === 'council'}
-            className={`mode-btn ${mode === 'council' ? 'active' : ''}`}
-            onClick={() => setMode('council')}
-            disabled={isLoading}
-          >
-            Council Mode
-          </button>
-          <button
-            type="button"
-            role="radio"
-            aria-checked={mode === 'arena'}
-            className={`mode-btn ${mode === 'arena' ? 'active' : ''}`}
-            onClick={() => setMode('arena')}
-            disabled={isLoading}
-          >
-            Arena Debate
-          </button>
-        </div>
-
-        {/* Arena Round Count */}
-        {mode === 'arena' && arenaConfig && (
-          <div className="arena-config">
-            <label className="rounds-label">
-              <span>Debate Rounds: {arenaRoundCount}</span>
-              <input
-                type="range"
-                min={arenaConfig.min_rounds}
-                max={arenaConfig.max_rounds}
-                value={arenaRoundCount}
-                onChange={(e) => setArenaRoundCount(parseInt(e.target.value))}
+      {/* Attachment chips above ask-bar */}
+      {attachments.length > 0 && (
+        <div className="attachment-chips attachment-chips--bar">
+          {attachments.map((att) => (
+            <div key={att.id} className="attachment-chip">
+              {att.file_type === 'image' ? <Image size={14} /> : <FileText size={14} />}
+              <span className="attachment-name">{att.filename}</span>
+              <button
+                type="button"
+                className="attachment-remove"
+                onClick={() => handleRemoveAttachment(att.id)}
                 disabled={isLoading}
-                className="rounds-slider"
-              />
-            </label>
-            <span className="rounds-hint">Round 1: Initial positions, Rounds 2+: Deliberation</span>
-          </div>
-        )}
+                aria-label={`Remove ${att.filename}`}
+              >
+                <X size={12} aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
-        {/* Attachment Chips */}
-        {attachments.length > 0 && (
-          <div className="attachment-chips">
-            {attachments.map((att) => (
-              <div key={att.id} className="attachment-chip">
-                {att.file_type === 'image' ? <Image size={14} /> : <FileText size={14} />}
-                <span className="attachment-name">{att.filename}</span>
+      {/* Bottom ask-bar */}
+      <form className="ask-bar" onSubmit={handleSubmit}>
+        <div className="ask-bar-inner">
+          {/* Arena round count */}
+          {mode === 'arena' && arenaConfig && (
+            <div className="arena-config">
+              <label className="rounds-label">
+                <span className="rounds-label-text">
+                  Rounds:{' '}
+                  <span className="mono-count" aria-label={`${arenaRoundCount} rounds`}>
+                    {arenaRoundCount}
+                  </span>
+                </span>
+                <input
+                  type="range"
+                  min={arenaConfig.min_rounds}
+                  max={arenaConfig.max_rounds}
+                  value={arenaRoundCount}
+                  onChange={(e) => setArenaRoundCount(parseInt(e.target.value))}
+                  disabled={isLoading}
+                  className="rounds-slider"
+                  aria-label="Number of debate rounds"
+                />
+              </label>
+            </div>
+          )}
+          <div className="ask-bar-row">
+            <div className="ask-bar-chips">
+              {webSearchAvailable && (
                 <button
                   type="button"
-                  className="attachment-remove"
-                  onClick={() => handleRemoveAttachment(att.id)}
+                  className={`ghost-chip${useWebSearch ? ' ghost-chip--active' : ''}`}
+                  onClick={toggleWebSearch}
                   disabled={isLoading}
-                  aria-label={`Remove ${att.filename}`}
+                  title={`Search via ${searchProvider === 'tavily' ? 'Tavily' : 'DuckDuckGo'}`}
                 >
-                  <X size={12} aria-hidden="true" />
+                  <Globe size={12} strokeWidth={2} aria-hidden="true" />
+                  web search
                 </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        <div className="input-controls">
-          {/* File attachment button */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            className="file-input-hidden"
-            onChange={handleFileSelect}
-            disabled={isLoading || uploadingFile}
-            multiple
-            accept=".txt,.md,.json,.csv,.xml,.html,.py,.js,.ts,.pdf,.png,.jpg,.jpeg,.gif,.webp"
-          />
-          <button
-            type="button"
-            className="attach-btn"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isLoading || uploadingFile}
-            aria-label="Attach files (PDF, images, text)"
-          >
-            <Paperclip size={18} aria-hidden="true" />
-            {uploadingFile && (
-              <span className="uploading-indicator" aria-live="polite">
-                Uploading...
-              </span>
-            )}
-          </button>
-
-          {webSearchAvailable && (
-            <label
-              className="web-search-toggle"
-              title={`Search via ${searchProvider === 'tavily' ? 'Tavily' : 'DuckDuckGo'}`}
-            >
-              <input
-                type="checkbox"
-                checked={useWebSearch}
-                onChange={toggleWebSearch}
+              )}
+              <button
+                type="button"
+                className="ghost-chip"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isLoading || uploadingFile}
+              >
+                <Paperclip size={12} strokeWidth={2} aria-hidden="true" />
+                {uploadingFile ? 'uploading…' : 'attach'}
+              </button>
+            </div>
+            <div className="ask-bar-input-wrap">
+              <textarea
+                className="ask-bar-input"
+                placeholder="Ask a follow-up… (Enter to send)"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
                 disabled={isLoading}
+                rows={1}
               />
-              <span className="toggle-label">
-                🔍 Web Search
-                {searchProvider && (
-                  <span className="provider-badge">
-                    {searchProvider === 'tavily' ? 'Tavily' : 'DDG'}
-                  </span>
-                )}
-              </span>
-            </label>
-          )}
-          {(isLoading || isExtendingDebate) ? (
-            <button
-              type="button"
-              className="cancel-button"
-              onClick={onCancel}
-              title="Cancel stream (Esc)"
-            >
-              Cancel
-            </button>
-          ) : (
-            <button type="submit" className="send-button" disabled={!input.trim()}>
-              {mode === 'arena' ? 'Start Debate' : 'Send'}
-            </button>
-          )}
+            </div>
+            {isLoading || isExtendingDebate ? (
+              <button
+                type="button"
+                className="ask-bar-cancel"
+                onClick={onCancel}
+                title="Cancel stream (Esc)"
+              >
+                Cancel
+              </button>
+            ) : (
+              <button type="submit" className="ask-bar-send" disabled={!input.trim()}>
+                Send
+                <ArrowRight size={13} strokeWidth={2} aria-hidden="true" />
+              </button>
+            )}
+          </div>
         </div>
       </form>
     </div>

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -211,7 +211,8 @@ export default function ChatInterface({
   );
 
   const showLanding =
-    !conversation || (conversation.messages.length === 0 && !conversation.pendingInterrupted);
+    !conversation ||
+    (conversation.messages.length === 0 && !conversation.pendingInterrupted && !pendingForkContext);
 
   // ── Topbar — persistent across landing and conversation views ──────────────
   const topBar = (

--- a/frontend/src/components/MetricsDisplay.css
+++ b/frontend/src/components/MetricsDisplay.css
@@ -1,15 +1,14 @@
-/* Metrics Display - Elegant Ledger Style */
+/* Metrics Display */
 .metrics-display {
-  background: linear-gradient(135deg, #FFFDF5 0%, #FFF9E6 100%);
-  border: 1px solid var(--color-gold-light);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   margin-top: var(--space-lg);
   overflow: hidden;
-  box-shadow: var(--shadow-subtle);
   position: relative;
 }
 
-/* Decorative top border */
+/* Accent top edge */
 .metrics-display::before {
   content: '';
   position: absolute;
@@ -17,23 +16,25 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     transparent 0%,
-    var(--color-gold) 15%,
-    var(--color-gold) 85%,
+    var(--accent) 15%,
+    var(--accent) 85%,
     transparent 100%
   );
+  opacity: 0.5;
 }
 
 .metrics-summary {
   padding: var(--space-md) var(--space-lg);
   cursor: pointer;
   user-select: none;
-  transition: background var(--transition-fast);
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
 .metrics-summary:hover {
-  background: rgba(196, 163, 90, 0.08);
+  background: var(--surface-hover);
 }
 
 .metrics-row {
@@ -50,59 +51,51 @@
 }
 
 .metric-icon {
-  font-size: 0.875rem;
-  opacity: 0.8;
+  color: var(--fg-faint);
+  flex: none;
 }
 
 .metric-value {
   font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.8125rem;
-  color: var(--color-text-primary);
+  font-size: 13px;
+  color: var(--fg);
 }
 
 .metric-label {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--fg-faint);
+  font-family: var(--font-display);
 }
 
 .expand-btn {
   margin-left: auto;
-  background: none;
-  border: 1px solid var(--color-gold-light);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  font-size: 0.625rem;
-  color: var(--color-gold-dark);
+  color: var(--fg-faint);
   cursor: pointer;
   padding: var(--space-xs) var(--space-sm);
-  font-family: var(--font-mono);
-  transition: background var(--transition-fast), color var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .expand-btn:hover {
-  background: var(--color-gold-light);
-  color: var(--color-text-primary);
+  background: var(--surface-hover);
+  color: var(--fg-subtle);
 }
 
-/* Expanded Details */
+/* Expanded details */
 .metrics-details {
-  border-top: 1px solid var(--color-gold-light);
+  border-top: 1px solid var(--line);
   padding: var(--space-lg);
-  background: var(--color-surface);
-  animation: slideDown 0.2s ease-out;
+  background: var(--bg-sunken);
+  animation: ccFade var(--dur-standard) var(--ease-out);
   -webkit-backface-visibility: hidden;
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .stage-metrics {
@@ -116,52 +109,52 @@
   grid-template-columns: 1fr 70px 90px 70px;
   gap: var(--space-sm);
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 12px;
   padding: var(--space-xs) var(--space-sm);
-  background: var(--color-surface);
+  background: var(--bg-raised);
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid var(--line);
 }
 
 .stage-name {
-  color: var(--color-text-secondary);
-  font-family: var(--font-body);
+  color: var(--fg-subtle);
+  font-family: var(--font-display);
   font-weight: 500;
 }
 
 .stage-cost {
   font-family: var(--font-mono);
-  color: var(--color-gold-dark);
+  color: var(--fg);
   font-weight: 600;
 }
 
 .stage-tokens {
   font-family: var(--font-mono);
-  color: var(--color-text-secondary);
-  font-size: 0.6875rem;
+  color: var(--fg-subtle);
+  font-size: 11px;
 }
 
 .stage-latency {
   font-family: var(--font-mono);
-  color: var(--color-text-muted);
-  font-size: 0.6875rem;
+  color: var(--fg-faint);
+  font-size: 11px;
   text-align: right;
 }
 
-/* Per-Model Details */
+/* Per-model breakdown */
 .model-metrics {
   margin-top: var(--space-md);
   padding-top: var(--space-md);
-  border-top: 1px dashed var(--color-gold-light);
+  border-top: 1px dashed var(--line);
 }
 
 .model-metrics-header {
-  font-size: 0.6875rem;
-  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-faint);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: var(--space-sm);
-  font-family: var(--font-mono);
 }
 
 .model-row {
@@ -169,18 +162,18 @@
   grid-template-columns: 1fr 55px 55px 70px;
   gap: var(--space-xs);
   align-items: center;
-  font-size: 0.6875rem;
+  font-size: 11px;
   padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
-  transition: background var(--transition-fast);
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
 .model-row:hover {
-  background: var(--color-parchment);
+  background: var(--surface-hover);
 }
 
 .model-row .model-name {
-  color: var(--color-text-secondary);
+  color: var(--fg-subtle);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -189,19 +182,19 @@
 
 .model-cost {
   font-family: var(--font-mono);
-  color: var(--color-gold-dark);
+  color: var(--fg);
   font-weight: 500;
 }
 
 .model-latency {
   font-family: var(--font-mono);
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
 }
 
 .model-provider {
-  color: var(--color-text-muted);
-  font-size: 0.6875rem;
-  text-align: right;
   font-family: var(--font-mono);
+  color: var(--fg-faint);
+  font-size: 10px;
+  text-align: right;
   opacity: 0.7;
 }

--- a/frontend/src/components/MetricsDisplay.jsx
+++ b/frontend/src/components/MetricsDisplay.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ChevronDown, ChevronUp, Coins, Hash, RotateCw } from 'lucide-react';
 import { formatCostAlways, formatLatency, formatTokens } from '../lib/formatting';
 import './MetricsDisplay.css';
 
@@ -22,22 +23,25 @@ export default function MetricsDisplay({ metrics }) {
       <div className="metrics-summary" onClick={() => setExpanded(!expanded)}>
         <div className="metrics-row">
           <div className="metric">
-            <span className="metric-icon">💰</span>
+            <Coins size={14} strokeWidth={2} className="metric-icon" />
             <span className="metric-value">{formatCostAlways(metrics.total_cost)}</span>
             <span className="metric-label">cost</span>
           </div>
           <div className="metric">
-            <span className="metric-icon">📝</span>
+            <Hash size={14} strokeWidth={2} className="metric-icon" />
             <span className="metric-value">{formatTokens(metrics.total_tokens)}</span>
             <span className="metric-label">tokens</span>
           </div>
           <div className="metric">
-            <span className="metric-icon">⏱️</span>
+            <RotateCw size={14} strokeWidth={2} className="metric-icon" />
             <span className="metric-value">{formatLatency(metrics.total_latency_ms)}</span>
             <span className="metric-label">latency</span>
           </div>
-          <button className="expand-btn" aria-label={expanded ? 'Collapse' : 'Expand'}>
-            {expanded ? '▲' : '▼'}
+          <button
+            className="expand-btn"
+            aria-label={expanded ? 'Collapse metrics' : 'Expand metrics'}
+          >
+            {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
           </button>
         </div>
       </div>
@@ -70,7 +74,9 @@ export default function MetricsDisplay({ metrics }) {
               <div className="model-metrics-header">Per-Model Breakdown</div>
               {responses.models?.map((m, i) => (
                 <div key={`s1-${i}`} className="model-row">
-                  <span className="model-name" title={m.model}>{m.model?.split('/').pop()}</span>
+                  <span className="model-name" title={m.model}>
+                    {m.model?.split('/').pop()}
+                  </span>
                   <span className="model-cost">{formatCostAlways(m.cost)}</span>
                   <span className="model-latency">{formatLatency(m.latency_ms)}</span>
                   <span className="model-provider">{m.provider}</span>

--- a/frontend/src/components/MetricsDisplay.jsx
+++ b/frontend/src/components/MetricsDisplay.jsx
@@ -72,8 +72,8 @@ export default function MetricsDisplay({ metrics }) {
           {(responses.models?.length > 0 || rankings.models?.length > 0) && (
             <div className="model-metrics">
               <div className="model-metrics-header">Per-Model Breakdown</div>
-              {responses.models?.map((m, i) => (
-                <div key={`s1-${i}`} className="model-row">
+              {responses.models?.map((m) => (
+                <div key={m.model} className="model-row">
                   <span className="model-name" title={m.model}>
                     {m.model?.split('/').pop()}
                   </span>

--- a/frontend/src/components/ModelCuration.css
+++ b/frontend/src/components/ModelCuration.css
@@ -1,166 +1,134 @@
-/* Model Curation Modal - Modal-specific styles only */
-/* Shared model group styles are in models/ModelGroups.css */
+/* ModelCuration — curation modal
+ * Modal chrome (.cc-modal-backdrop/panel/header/body/footer) is in index.css.
+ * This file owns curation-specific content: description, results row,
+ * curated count badge, footer buttons, and model-groups height override. */
 
-/* Overlay */
-.curation-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: var(--space-lg);
-}
-
-/* Modal Container */
-.curation-modal {
-  background: var(--color-surface);
-  border-radius: var(--radius-xl);
-  width: 100%;
+/* Wider panel for the curation modal */
+.mc-panel {
   max-width: 700px;
-  max-height: 85vh;
+}
+
+/* ── Header title group ─────────────────────────────────────────────────── */
+.mc-title-group {
   display: flex;
   flex-direction: column;
-  box-shadow: var(--shadow-xl);
-  overflow: hidden;
+  gap: 2px;
 }
 
-/* Header */
-.curation-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-lg) var(--space-xl);
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-parchment);
-  flex-shrink: 0;
+.cc-modal-title .mc-title-icon {
+  vertical-align: middle;
+  margin-right: 6px;
+  margin-bottom: 2px;
+  color: var(--warning);
 }
 
-.curation-title {
+/* ── Body ───────────────────────────────────────────────────────────────── */
+.mc-body {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-sm);
-  color: var(--color-burgundy);
 }
 
-.curation-title h2 {
+.mc-description {
   margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 600;
+  color: var(--fg-subtle);
+  font-size: 13px;
+  line-height: 1.55;
 }
 
-.curation-close {
-  background: none;
-  border: none;
-  padding: var(--space-xs);
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  border-radius: var(--radius-sm);
-  transition: background, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.curation-close:hover {
-  background: var(--color-border-light);
-  color: var(--color-text-primary);
-}
-
-/* Body - Scrollable Content */
-.curation-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--space-lg) var(--space-xl);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  min-height: 0;
-}
-
-.curation-description {
-  margin: 0;
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
-  line-height: 1.5;
-}
-
-.curation-error {
-  padding: var(--space-sm) var(--space-md);
-  background: #fef2f2;
-  color: #dc2626;
-  font-size: 0.875rem;
-  border-radius: var(--radius-md);
+/* Error banner */
+.mc-error {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: 13px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--danger);
 }
 
-.curation-error .retry-btn {
+.mc-retry-btn {
   padding: var(--space-xs) var(--space-sm);
-  background: #dc2626;
-  color: white;
+  background: var(--danger);
+  color: var(--fg-on-accent);
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-family: var(--font-display);
+  font-size: 12px;
+  flex-shrink: 0;
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
-.curation-results {
+.mc-retry-btn:hover {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+/* Results / status row */
+.mc-results-row {
   display: flex;
   align-items: center;
   gap: var(--space-md);
-  font-size: 0.875rem;
-  color: var(--color-text-secondary);
+  font-size: 12.5px;
+  color: var(--fg-subtle);
+}
+
+.mc-model-count {
+  font-family: var(--font-display);
+}
+
+.mc-num {
   font-family: var(--font-mono);
+  font-size: 12.5px;
 }
 
-.curation-results .curated-count {
-  display: flex;
+.mc-curated-count {
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  color: var(--color-burgundy);
-  font-weight: 500;
+  gap: 4px;
+  color: var(--warning);
+  font-family: var(--font-display);
 }
 
-.curation-results .refresh-btn {
+.mc-refresh-btn {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border);
+  gap: 5px;
+  padding: 5px 11px;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--fg-subtle);
   cursor: pointer;
-  transition: background, border-color, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.curation-results .refresh-btn:hover:not(:disabled) {
-  background: var(--color-parchment);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+.mc-refresh-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
-.curation-results .refresh-btn:disabled {
-  opacity: 0.6;
+.mc-refresh-btn:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-.curation-results .refresh-btn.refreshing svg {
-  animation: spin 1s linear infinite;
+.mc-refresh-btn--spinning svg {
+  animation: mc-spin var(--dur-deliberate) linear infinite;
 }
 
-@keyframes spin {
+@keyframes mc-spin {
   from {
     transform: rotate(0deg);
   }
@@ -169,155 +137,73 @@
   }
 }
 
-/* Override model-groups height for modal context */
-.curation-body .model-groups {
+/* ModelGroups height override for curation modal */
+.mc-body .model-groups {
   flex: 1;
   min-height: 300px;
-  max-height: none;
+  max-height: calc(84vh - 320px);
 }
 
-/* Footer */
-.curation-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-md);
-  padding: var(--space-lg) var(--space-xl);
-  border-top: 1px solid var(--color-border);
-  background: var(--color-parchment);
-  flex-shrink: 0;
+/* ── Loading state ──────────────────────────────────────────────────────── */
+.mc-status-loading {
+  padding: var(--space-2xl) var(--space-xl);
+  text-align: center;
+  color: var(--fg-subtle);
+  font-size: 14px;
+  font-style: italic;
 }
 
-.curation-footer .cancel-btn {
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+/* ── Footer buttons ─────────────────────────────────────────────────────── */
+/* .cc-modal-footer provides layout (space-between) from index.css */
+
+.mc-cancel-btn {
+  padding: 8px 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  font-size: 0.875rem;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  transition: background, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
-}
-
-.curation-footer .cancel-btn:hover:not(:disabled) {
-  background: var(--color-border-light);
-  color: var(--color-text-primary);
-}
-
-.curation-footer .save-btn {
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--color-burgundy);
-  color: white;
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: 0.875rem;
+  font-family: var(--font-display);
+  font-size: 13.5px;
   font-weight: 500;
+  color: var(--fg-muted);
   cursor: pointer;
-  transition: background;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.curation-footer .save-btn:hover:not(:disabled) {
-  background: var(--color-burgundy-dark, #6d1f2a);
+.mc-cancel-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
 }
 
-.curation-footer .cancel-btn:disabled,
-.curation-footer .save-btn:disabled {
-  opacity: 0.6;
+.mc-cancel-btn:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-/* Loading State */
-.curation-loading {
-  padding: var(--space-2xl);
-  text-align: center;
-  color: var(--color-text-secondary);
-}
-
-/* Search and Filter - inherit from shared styles */
-.curation-body .search-box {
-  position: relative;
-}
-
-.curation-body .search-input {
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  padding-right: var(--space-xl);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: 0.875rem;
-  background: var(--color-surface);
-  color: var(--color-text-primary);
-  transition: border-color, box-shadow;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
-}
-
-.curation-body .search-input:focus {
-  outline: none;
-  border-color: var(--color-burgundy);
-  box-shadow: 0 0 0 3px rgba(139, 38, 53, 0.1);
-}
-
-.curation-body .search-clear {
-  position: absolute;
-  right: var(--space-sm);
-  top: 50%;
-  transform: translateY(-50%);
-  background: var(--color-parchment);
+.mc-save-btn {
+  padding: 8px 20px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
   border: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    box-shadow var(--dur-micro) var(--ease-out);
 }
 
-.curation-body .search-clear:hover {
-  background: var(--color-border);
-  color: var(--color-text-primary);
+.mc-save-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: var(--shadow-sm);
 }
 
-.curation-body .filter-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-}
-
-.curation-body .filter-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: var(--space-xs) var(--space-md);
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  font-size: 0.875rem;
-  color: var(--color-text-secondary);
-  background: var(--color-ivory);
-  cursor: pointer;
-  transition: background, border-color, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
-  user-select: none;
-}
-
-.curation-body .filter-chip input[type='checkbox'] {
-  display: none;
-}
-
-.curation-body .filter-chip:hover {
-  background: var(--color-parchment);
-  border-color: var(--color-text-muted);
-}
-
-.curation-body .filter-chip.active {
-  background: var(--color-burgundy);
-  border-color: var(--color-burgundy);
-  color: white;
+.mc-save-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }

--- a/frontend/src/components/ModelCuration.jsx
+++ b/frontend/src/components/ModelCuration.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { X, Star, RefreshCw } from 'lucide-react';
 import { useModels, useCuratedModels, useModelFiltering, useExpandableGroups } from '../hooks';
 import { ModelSearchBox, FilterChips, ModelGroups } from './models/index.js';
@@ -94,6 +94,13 @@ export default function ModelCuration({ onClose, onSave }) {
   };
 
   const error = modelsError || saveError;
+  const searchInputRef = useRef(null);
+
+  // Auto-focus the search input when the modal opens
+  useEffect(() => {
+    const timer = setTimeout(() => searchInputRef.current?.focus(), 50);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Close on Escape
   useEffect(() => {
@@ -118,7 +125,13 @@ export default function ModelCuration({ onClose, onSave }) {
   // ── Main render ────────────────────────────────────────────────────────
   return (
     <div className="cc-modal-backdrop" onClick={onClose}>
-      <div className="cc-modal-panel mc-panel" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="cc-modal-panel mc-panel"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Curate your models"
+      >
         {/* Header */}
         <div className="cc-modal-header">
           <div className="mc-title-group">
@@ -148,7 +161,7 @@ export default function ModelCuration({ onClose, onSave }) {
             </div>
           )}
 
-          <ModelSearchBox value={searchQuery} onChange={setSearchQuery} />
+          <ModelSearchBox ref={searchInputRef} value={searchQuery} onChange={setSearchQuery} />
 
           <FilterChips filters={filters} showCuratedFilter={false} showContextFilter={false} />
 

--- a/frontend/src/components/ModelCuration.jsx
+++ b/frontend/src/components/ModelCuration.jsx
@@ -5,8 +5,8 @@ import { ModelSearchBox, FilterChips, ModelGroups } from './models/index.js';
 import './ModelCuration.css';
 
 /**
- * Model curation modal for selecting favorite models.
- * Mirrors ModelSelector structure for consistency.
+ * Model curation modal — select favourite models for the curated list.
+ * Uses shared .cc-modal-* chrome from index.css.
  */
 export default function ModelCuration({ onClose, onSave }) {
   // Fetch models
@@ -24,7 +24,7 @@ export default function ModelCuration({ onClose, onSave }) {
     error: saveError,
   } = curated;
 
-  // Filtering - no curated filter in curation mode
+  // Filtering — no curated filter in curation mode
   const filtering = useModelFiltering(models, curatedIds);
   const {
     groupedModels,
@@ -95,7 +95,7 @@ export default function ModelCuration({ onClose, onSave }) {
 
   const error = modelsError || saveError;
 
-  // Close on escape key
+  // Close on Escape
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') onClose();
@@ -104,39 +104,45 @@ export default function ModelCuration({ onClose, onSave }) {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
+  // ── Loading state ──────────────────────────────────────────────────────
   if (loading || curated.loading) {
     return (
-      <div className="curation-overlay" onClick={onClose}>
-        <div className="curation-modal" onClick={(e) => e.stopPropagation()}>
-          <div className="curation-loading">Loading models...</div>
+      <div className="cc-modal-backdrop" onClick={onClose}>
+        <div className="cc-modal-panel mc-panel" onClick={(e) => e.stopPropagation()}>
+          <div className="mc-status-loading">Loading models…</div>
         </div>
       </div>
     );
   }
 
+  // ── Main render ────────────────────────────────────────────────────────
   return (
-    <div className="curation-overlay" onClick={onClose}>
-      <div className="curation-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="curation-header">
-          <div className="curation-title">
-            <Star size={20} />
-            <h2>Curate Your Models</h2>
+    <div className="cc-modal-backdrop" onClick={onClose}>
+      <div className="cc-modal-panel mc-panel" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="cc-modal-header">
+          <div className="mc-title-group">
+            <div className="cc-modal-title">
+              <Star size={18} className="mc-title-icon" aria-hidden="true" />
+              Curate Your Models
+            </div>
           </div>
-          <button className="curation-close" onClick={onClose} aria-label="Close">
-            <X size={20} />
+          <button className="cc-modal-close" onClick={onClose} aria-label="Close">
+            <X size={16} />
           </button>
         </div>
 
-        <div className="curation-body">
-          <p className="curation-description">
-            Select your favorite models to create a curated list. Only curated models will appear
-            in the model selector.
+        {/* Body */}
+        <div className="cc-modal-body mc-body">
+          <p className="mc-description">
+            Select your favourite models to create a curated list. Only curated models will appear
+            in the model selector by default.
           </p>
 
           {error && (
-            <div className="curation-error">
+            <div className="mc-error">
               {error}
-              <button onClick={refetch} className="retry-btn">
+              <button onClick={refetch} className="mc-retry-btn">
                 Retry
               </button>
             </div>
@@ -144,27 +150,25 @@ export default function ModelCuration({ onClose, onSave }) {
 
           <ModelSearchBox value={searchQuery} onChange={setSearchQuery} />
 
-          <FilterChips
-            filters={filters}
-            showCuratedFilter={false}
-            showContextFilter={false}
-          />
+          <FilterChips filters={filters} showCuratedFilter={false} showContextFilter={false} />
 
-          <div className="curation-results">
-            <span>
-              {filteredCount} of {totalCount} models
+          <div className="mc-results-row">
+            <span className="mc-model-count">
+              <span className="mc-num">{filteredCount}</span> of{' '}
+              <span className="mc-num">{totalCount}</span> models
             </span>
-            <span className="curated-count">
-              <Star size={14} /> {curatedIds.size} curated
+            <span className="mc-curated-count">
+              <Star size={13} aria-hidden="true" />
+              <span className="mc-num">{curatedIds.size}</span> curated
             </span>
             <button
-              className={`refresh-btn ${refreshing ? 'refreshing' : ''}`}
+              className={`mc-refresh-btn${refreshing ? ' mc-refresh-btn--spinning' : ''}`}
               onClick={refresh}
               disabled={refreshing}
               title="Refresh models from OpenRouter"
             >
               <RefreshCw size={14} />
-              {refreshing ? 'Refreshing...' : 'Refresh'}
+              {refreshing ? 'Refreshing…' : 'Refresh'}
             </button>
           </div>
 
@@ -182,12 +186,13 @@ export default function ModelCuration({ onClose, onSave }) {
           />
         </div>
 
-        <div className="curation-footer">
-          <button className="cancel-btn" onClick={onClose} disabled={saving}>
+        {/* Footer */}
+        <div className="cc-modal-footer">
+          <button className="mc-cancel-btn" onClick={onClose} disabled={saving}>
             Cancel
           </button>
-          <button className="save-btn" onClick={handleSave} disabled={saving}>
-            {saving ? 'Saving...' : `Save ${curatedIds.size} Models`}
+          <button className="mc-save-btn" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : `Save ${curatedIds.size} Models`}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ModelErrors.css
+++ b/frontend/src/components/ModelErrors.css
@@ -16,28 +16,38 @@
   margin-top: var(--space-xs);
 }
 
+/* Billing — warning palette */
 .model-errors-banner--billing {
-  background: #fff8e1;
-  border: 1px solid #ffcc02;
-  color: #6d5100;
+  background: var(--warning-soft);
+  border: 1px solid var(--warning);
+  color: var(--warning);
 }
 
+/* Auth — danger palette */
 .model-errors-banner--auth {
-  background: #ffeef0;
-  border: 1px solid #f97583;
-  color: #86181d;
+  background: var(--danger-soft);
+  border: 1px solid var(--danger);
+  color: var(--danger);
 }
 
+/* Transient / rate-limit / timeout — neutral */
 .model-errors-banner--transient {
-  background: #f6f8fa;
-  border: 1px solid #d0d7de;
-  color: #57606a;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  color: var(--fg-subtle);
+}
+
+/* Unknown / generic error — warning palette (softer than danger) */
+.model-errors-banner--unknown {
+  background: var(--warning-soft);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-subtle);
 }
 
 .model-errors-icon {
   flex-shrink: 0;
-  font-size: 1rem;
-  line-height: 1;
+  margin-top: 1px;
+  opacity: 0.85;
 }
 
 .model-errors-body {
@@ -59,6 +69,8 @@
   font-family: var(--font-mono);
   font-size: 0.7rem;
   margin-top: 2px;
+  color: inherit;
+  opacity: 0.75;
 }
 
 .model-errors-link {
@@ -71,16 +83,20 @@
   align-items: center;
   margin-top: var(--space-sm);
   padding: 4px 12px;
+  font-family: var(--font-mono);
   font-size: 0.75rem;
   font-weight: 600;
-  color: #57606a;
-  background: #f6f8fa;
-  border: 1px solid #d0d7de;
+  color: var(--fg-subtle);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
   cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out);
 }
 
 .model-errors-retry-btn:hover {
-  background: #eaeef2;
-  border-color: #afb8c1;
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
 }

--- a/frontend/src/components/ModelErrors.jsx
+++ b/frontend/src/components/ModelErrors.jsx
@@ -1,3 +1,4 @@
+import { CreditCard, KeyRound, Zap, AlertTriangle } from 'lucide-react';
 import './ModelErrors.css';
 
 /**
@@ -23,11 +24,12 @@ export default function ModelErrors({ errors, onRetry }) {
     <div className="model-errors">
       {groups.billing && (
         <div className="model-errors-banner model-errors-banner--billing">
-          <span className="model-errors-icon">💳</span>
+          <CreditCard size={15} strokeWidth={2} className="model-errors-icon" />
           <div className="model-errors-body">
             <div className="model-errors-title">Insufficient OpenRouter credits</div>
             <div className="model-errors-detail">
-              {groups.billing.length} model{groups.billing.length > 1 ? 's' : ''} failed due to billing.{' '}
+              {groups.billing.length} model{groups.billing.length > 1 ? 's' : ''} failed due to
+              billing.{' '}
               <a
                 href="https://openrouter.ai/credits"
                 target="_blank"
@@ -46,22 +48,21 @@ export default function ModelErrors({ errors, onRetry }) {
 
       {groups.auth && (
         <div className="model-errors-banner model-errors-banner--auth">
-          <span className="model-errors-icon">🔑</span>
+          <KeyRound size={15} strokeWidth={2} className="model-errors-icon" />
           <div className="model-errors-body">
             <div className="model-errors-title">API key error</div>
             <div className="model-errors-detail">
-              {groups.auth.length} model{groups.auth.length > 1 ? 's' : ''} rejected the API key. Check your OpenRouter API key configuration.
+              {groups.auth.length} model{groups.auth.length > 1 ? 's' : ''} rejected the API key.
+              Check your OpenRouter API key configuration.
             </div>
-            <div className="model-errors-models">
-              {groups.auth.map((e) => e.model).join(', ')}
-            </div>
+            <div className="model-errors-models">{groups.auth.map((e) => e.model).join(', ')}</div>
           </div>
         </div>
       )}
 
       {groups.transient && (
         <div className="model-errors-banner model-errors-banner--transient">
-          <span className="model-errors-icon">⚡</span>
+          <Zap size={15} strokeWidth={2} className="model-errors-icon" />
           <div className="model-errors-body">
             <div className="model-errors-title">
               {groups.transient.length} model{groups.transient.length > 1 ? 's' : ''} unavailable
@@ -74,8 +75,8 @@ export default function ModelErrors({ errors, onRetry }) {
       )}
 
       {groups.unknown && (
-        <div className="model-errors-banner model-errors-banner--transient">
-          <span className="model-errors-icon">⚠️</span>
+        <div className="model-errors-banner model-errors-banner--unknown">
+          <AlertTriangle size={15} strokeWidth={2} className="model-errors-icon" />
           <div className="model-errors-body">
             <div className="model-errors-title">
               {groups.unknown.length} model{groups.unknown.length > 1 ? 's' : ''} failed
@@ -88,11 +89,7 @@ export default function ModelErrors({ errors, onRetry }) {
       )}
 
       {onRetry && (
-        <button
-          type="button"
-          className="model-errors-retry-btn"
-          onClick={onRetry}
-        >
+        <button type="button" className="model-errors-retry-btn" onClick={onRetry}>
           Retry All Models
         </button>
       )}

--- a/frontend/src/components/ModelSelector.css
+++ b/frontend/src/components/ModelSelector.css
@@ -148,6 +148,11 @@
   border-color: var(--accent);
 }
 
+.context-filter:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
 /* Provider filter chips row */
 .provider-chips {
   display: flex;

--- a/frontend/src/components/ModelSelector.css
+++ b/frontend/src/components/ModelSelector.css
@@ -1,41 +1,50 @@
-/* Model Selector - Configuration Panel */
-/* Shared model group styles are in models/ModelGroups.css */
+/* ModelSelector — council configuration modal
+ * Modal chrome itself comes from .cc-modal-* in index.css.
+ * This file owns the search box, filter bar, count row, footer buttons,
+ * and the ms-* council-variant helpers in ModelGroups. */
 
-.model-selector {
-  padding: 20px 24px;
-  overflow-y: auto;
-  flex: 1;
-  min-height: 0;
-}
-
-/* Search Box */
+/* ── Search box ─────────────────────────────────────────────────────────── */
 .search-box {
   position: relative;
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--fg-faint);
+  pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  padding-right: var(--space-xl);
-  border: 1px solid var(--color-border);
+  padding: 9px var(--space-xl) 9px var(--space-md);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  background: var(--color-surface);
-  color: var(--color-text-primary);
-  transition: border-color, box-shadow;
-  transition-duration: var(--transition-fast);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  background: var(--bg-sunken);
+  color: var(--fg);
+  transition:
+    border-color var(--dur-micro) var(--ease-out),
+    box-shadow var(--dur-micro) var(--ease-out);
+}
+
+/* Left-side icon variant */
+.search-input--icon {
+  padding-left: 32px;
 }
 
 .search-input:focus {
   outline: none;
-  border-color: var(--color-burgundy);
-  box-shadow: 0 0 0 3px rgba(139, 38, 53, 0.1);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
 .search-input::placeholder {
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
 }
 
 .search-clear {
@@ -43,136 +52,170 @@
   right: var(--space-sm);
   top: 50%;
   transform: translateY(-50%);
-  background: var(--color-parchment);
+  background: none;
   border: none;
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   cursor: pointer;
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background, color;
-  transition-duration: var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .search-clear:hover {
-  background: var(--color-border);
-  color: var(--color-text-primary);
+  background: var(--surface-hover);
+  color: var(--fg);
 }
 
-/* Filter Bar */
+/* ── Filter bar ─────────────────────────────────────────────────────────── */
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
 }
 
 .filter-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  font-size: 0.9375rem;
-  color: var(--color-text-secondary);
-  background: var(--color-ivory);
+  gap: 5px;
+  padding: 5px 13px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-family: var(--font-display);
+  color: var(--fg-subtle);
+  background: var(--surface);
   cursor: pointer;
-  transition: background, border-color, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
   user-select: none;
 }
 
-.filter-chip input[type="checkbox"] {
+.filter-chip input[type='checkbox'] {
   display: none;
 }
 
 .filter-chip:hover {
-  background: var(--color-parchment);
-  border-color: var(--color-text-muted);
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
 }
 
 .filter-chip.active {
-  background: var(--color-burgundy);
-  border-color: var(--color-burgundy);
-  color: white;
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .filter-chip.curated {
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+  /* no special inactive look — matches base chip */
 }
 
 .filter-chip.curated.active {
-  background: var(--color-burgundy);
-  color: white;
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Mono count number inside a chip label */
+.fc-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
 .context-filter {
-  padding: 8px 16px;
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  font-size: 0.9375rem;
-  color: var(--color-text-secondary);
-  background: var(--color-ivory);
+  padding: 5px 13px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-family: var(--font-display);
+  color: var(--fg-subtle);
+  background: var(--surface);
   cursor: pointer;
+  outline: none;
+  transition: border-color var(--dur-micro) var(--ease-out);
 }
 
 .context-filter:focus {
-  outline: none;
-  border-color: var(--color-burgundy);
+  border-color: var(--accent);
 }
 
-.filter-results-row {
+/* Provider filter chips row */
+.provider-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  width: 100%;
+  padding-top: 2px;
+}
+
+.provider-chip {
+  padding: 4px 11px;
+  font-size: 11.5px;
+}
+
+/* ── Filter results row ─────────────────────────────────────────────────── */
+.ms-filter-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-sm);
 }
 
-.filter-results-count {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary);
+.ms-filter-count {
+  font-size: 12px;
+  color: var(--fg-subtle);
+  font-family: var(--font-display);
+}
+
+/* Mono count numbers used in labels + footer */
+.ms-count-num {
   font-family: var(--font-mono);
+  font-size: 12px;
 }
 
-.refresh-btn {
+.ms-refresh-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border);
+  gap: 5px;
+  padding: 5px 11px;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--fg-subtle);
   cursor: pointer;
-  transition: background, border-color, color;
-  transition-duration: var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.refresh-btn:hover:not(:disabled) {
-  background: var(--color-parchment);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+.ms-refresh-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
-.refresh-btn:disabled {
-  opacity: 0.6;
+.ms-refresh-btn:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-.refresh-btn.refreshing svg {
-  animation: spin 1s linear infinite;
+.ms-refresh-btn--spinning svg {
+  animation: ms-spin var(--dur-deliberate) linear infinite;
 }
 
-@keyframes spin {
+@keyframes ms-spin {
   from {
     transform: rotate(0deg);
   }
@@ -181,134 +224,120 @@
   }
 }
 
-.model-selector-loading,
-.model-selector-error {
-  text-align: center;
-  padding: var(--space-2xl);
-  color: var(--color-text-secondary);
-  font-style: italic;
-}
-
-.model-selector-error {
-  color: var(--color-burgundy);
-}
-
-.retry-btn {
-  margin-left: var(--space-md);
-  padding: var(--space-xs) var(--space-md);
-  background: var(--color-burgundy);
-  color: white;
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  transition: background;
-  transition-duration: var(--transition-fast);
-}
-
-.retry-btn:hover {
-  background: var(--color-burgundy-dark);
-}
-
-/* Section Headers */
-.selector-section {
-  margin-bottom: var(--space-xl);
-}
-
-.selector-section h4 {
-  margin: 0 0 var(--space-xs) 0;
-  font-family: var(--font-display);
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.selector-help {
-  margin: 0 0 var(--space-md) 0;
-  font-size: 0.8125rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-}
-
-/* Model Selector specific overrides for shared styles */
-.model-selector .model-groups {
-  min-height: 400px;
-  max-height: calc(90vh - 350px);
-}
-
-/* Provider Filter Chips */
-.provider-chips {
+/* ── Body scroll area ───────────────────────────────────────────────────── */
+.ms-body {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  width: 100%;
-  padding-top: 4px;
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
-.provider-chip {
-  padding: 4px 12px;
-  font-size: 0.8125rem;
-  border-radius: 14px;
-}
-
-/* Action Buttons */
-.selector-actions {
-  display: flex;
-  gap: var(--space-md);
-  margin-top: var(--space-lg);
-  padding-top: var(--space-lg);
-  border-top: 1px solid var(--color-border);
-}
-
-.cancel-btn,
-.save-btn {
+/* ModelGroups inside the modal body — constrain height */
+.ms-body .model-groups {
   flex: 1;
-  padding: var(--space-md) var(--space-lg);
+  min-height: 200px;
+  max-height: calc(84vh - 340px);
+}
+
+/* ── Status states (loading / error) ────────────────────────────────────── */
+.ms-status-state {
+  padding: var(--space-2xl) var(--space-xl);
+  text-align: center;
+  color: var(--fg-subtle);
+  font-size: 14px;
+  font-style: italic;
+}
+
+.ms-status-state--error {
+  color: var(--danger);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+}
+
+.ms-retry-btn {
+  padding: var(--space-xs) var(--space-md);
+  background: var(--danger);
+  color: var(--fg-on-accent);
   border: none;
   border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  font-weight: 500;
   cursor: pointer;
-  transition: background, color, border-color, box-shadow, transform, opacity;
-  transition-duration: var(--transition-medium);
+  font-family: var(--font-display);
+  font-size: 13px;
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
-.cancel-btn {
-  background: var(--color-parchment);
-  color: var(--color-text-secondary);
-  border: 1px solid var(--color-border);
+.ms-retry-btn:hover {
+  background: var(--danger-soft);
+  color: var(--danger);
 }
 
-.cancel-btn:hover:not(:disabled) {
-  background: var(--color-border-light);
-  color: var(--color-text-primary);
+/* ── Footer ─────────────────────────────────────────────────────────────── */
+/* .cc-modal-footer layout (space-between) comes from index.css */
+
+.ms-footer-count {
+  font-size: 12.5px;
+  font-family: var(--font-display);
+  color: var(--fg-subtle);
 }
 
-.save-btn {
-  background: var(--color-burgundy);
-  color: white;
-  box-shadow: var(--shadow-subtle);
+.ms-footer-count .ms-count-num {
+  font-size: 12.5px;
 }
 
-.save-btn:hover:not(:disabled) {
-  background: var(--color-burgundy-dark);
-  box-shadow: var(--shadow-medium);
-  transform: translateY(-1px);
+.ms-footer-actions {
+  display: flex;
+  gap: var(--space-sm);
 }
 
-.save-btn:disabled,
-.cancel-btn:disabled {
+.ms-cancel-btn {
+  padding: 8px 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
+}
+
+.ms-cancel-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
+}
+
+.ms-cancel-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  transform: none;
 }
 
-.validation-warning {
-  margin-top: var(--space-sm);
-  font-size: 0.75rem;
-  color: var(--color-burgundy);
-  text-align: center;
-  font-style: italic;
+.ms-save-btn {
+  padding: 8px 20px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    box-shadow var(--dur-micro) var(--ease-out);
+}
+
+.ms-save-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.ms-save-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }

--- a/frontend/src/components/ModelSelector.jsx
+++ b/frontend/src/components/ModelSelector.jsx
@@ -138,7 +138,12 @@ export default function ModelSelector({
 
   const toggleCouncilMember = (modelId) => {
     if (selectedCouncil.includes(modelId)) {
-      onCouncilChange(selectedCouncil.filter((m) => m !== modelId));
+      const remaining = selectedCouncil.filter((m) => m !== modelId);
+      onCouncilChange(remaining);
+      // Keep the chairman invariant: the chair must be a council member.
+      if (modelId === selectedChairman) {
+        onChairmanChange(remaining[0] ?? '');
+      }
     } else {
       onCouncilChange([...selectedCouncil, modelId]);
     }

--- a/frontend/src/components/ModelSelector.jsx
+++ b/frontend/src/components/ModelSelector.jsx
@@ -1,12 +1,15 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Crown, X } from 'lucide-react';
+import { useSeatColors } from '../hooks/useSeatColors';
 import { useModelFiltering, useExpandableGroups } from '../hooks';
 import { useAvailableModels, useCuratedModels, useRefreshModels } from '../hooks/queries';
 import { ModelSearchBox, FilterChips, ModelGroups } from './models/index.js';
 import './ModelSelector.css';
 
 /**
- * Model selection UI for configuring council members and chairman.
+ * Model selection modal — configures council members and chairman in one view.
+ * Each model row has a ToggleSwitch (council membership) and a Crown button
+ * (chairman designation). Shared `.cc-modal-*` chrome from index.css.
  */
 export default function ModelSelector({
   selectedCouncil,
@@ -19,16 +22,30 @@ export default function ModelSelector({
 }) {
   const [saving, setSaving] = useState(false);
   const searchInputRef = useRef(null);
+  const { seatOf } = useSeatColors();
 
-  // Auto-focus the search input when the modal opens
+  // Auto-focus search when the modal opens
   useEffect(() => {
-    // Delay slightly so the modal animation completes and focus trap doesn't override
     const timer = setTimeout(() => searchInputRef.current?.focus(), 50);
     return () => clearTimeout(timer);
   }, []);
 
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
   // Fetch models and curated list
-  const { data: modelsData, isLoading: loading, error: modelsError, refetch } = useAvailableModels();
+  const {
+    data: modelsData,
+    isLoading: loading,
+    error: modelsError,
+    refetch,
+  } = useAvailableModels();
   const models = modelsData?.models || [];
   const error = modelsError ? 'Failed to load models' : null;
   const refreshModels = useRefreshModels();
@@ -39,10 +56,14 @@ export default function ModelSelector({
   const curatedIds = useMemo(() => new Set(curatedData?.curated_models || []), [curatedData]);
 
   // Filtering — restore saved filters or use curated defaults
-  const filtering = useModelFiltering(models, curatedIds, filterStateRef?.current ?? {
-    showCuratedOnly: curatedIds.size > 0,
-    showMajorOnly: curatedIds.size === 0,
-  });
+  const filtering = useModelFiltering(
+    models,
+    curatedIds,
+    filterStateRef?.current ?? {
+      showCuratedOnly: curatedIds.size > 0,
+      showMajorOnly: curatedIds.size === 0,
+    }
+  );
 
   const {
     groupedModels,
@@ -65,15 +86,17 @@ export default function ModelSelector({
       minContext: filters.minContext,
       selectedProviders: filters.selectedProviders,
     };
-  }, [filterStateRef, filters.showMajorOnly, filters.showFreeOnly, filters.showCuratedOnly, filters.minContext, filters.selectedProviders]);
+  }, [
+    filterStateRef,
+    filters.showMajorOnly,
+    filters.showFreeOnly,
+    filters.showCuratedOnly,
+    filters.minContext,
+    filters.selectedProviders,
+  ]);
 
-  // Expand/collapse state — separate for council and chairman sections
+  // Expand/collapse state
   const { isExpanded, toggle: toggleProvider, expandAll } = useExpandableGroups();
-  const {
-    isExpanded: isChairmanExpanded,
-    toggle: toggleChairmanProvider,
-    expandAll: expandAllChairman,
-  } = useExpandableGroups();
 
   // Auto-expand when searching
   useEffect(() => {
@@ -86,29 +109,25 @@ export default function ModelSelector({
   useEffect(() => {
     if (models.length > 0) {
       const providersWithSelected = new Set();
-      selectedCouncil.forEach(id => {
-        const model = models.find(m => m.id === id);
+      selectedCouncil.forEach((id) => {
+        const model = models.find((m) => m.id === id);
         if (model) providersWithSelected.add(model.provider || 'Other');
       });
+      if (selectedChairman) {
+        const chairModel = models.find((m) => m.id === selectedChairman);
+        if (chairModel) providersWithSelected.add(chairModel.provider || 'Other');
+      }
       if (providersWithSelected.size > 0) {
         expandAll(Array.from(providersWithSelected));
       }
-
-      // Expand chairman's provider group
-      if (selectedChairman) {
-        const chairmanModel = models.find(m => m.id === selectedChairman);
-        if (chairmanModel) {
-          expandAllChairman([chairmanModel.provider || 'Other']);
-        }
-      }
     }
-  }, [models, selectedCouncil, selectedChairman, expandAll, expandAllChairman]);
+  }, [models, selectedCouncil, selectedChairman, expandAll]);
 
-  // Count selected models per provider
+  // Count selected models per provider (for group header badges)
   const selectedPerProvider = useMemo(() => {
     const counts = {};
-    selectedCouncil.forEach(id => {
-      const model = models.find(m => m.id === id);
+    selectedCouncil.forEach((id) => {
+      const model = models.find((m) => m.id === id);
       if (model) {
         const provider = model.provider || 'Other';
         counts[provider] = (counts[provider] || 0) + 1;
@@ -119,7 +138,7 @@ export default function ModelSelector({
 
   const toggleCouncilMember = (modelId) => {
     if (selectedCouncil.includes(modelId)) {
-      onCouncilChange(selectedCouncil.filter(m => m !== modelId));
+      onCouncilChange(selectedCouncil.filter((m) => m !== modelId));
     } else {
       onCouncilChange([...selectedCouncil, modelId]);
     }
@@ -134,115 +153,123 @@ export default function ModelSelector({
     }
   };
 
+  const isValid = selectedCouncil.length >= 2 && selectedChairman;
+
+  // ── Loading state ──────────────────────────────────────────────────────
   if (loading || curatedLoading) {
     return (
-      <div className="model-selector">
-        <div className="model-selector-loading">Loading models...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="model-selector">
-        <div className="model-selector-error">
-          {error}
-          <button onClick={refetch} className="retry-btn">Retry</button>
+      <div className="cc-modal-backdrop" onClick={onCancel}>
+        <div className="cc-modal-panel" onClick={(e) => e.stopPropagation()}>
+          <div className="ms-status-state">Loading models…</div>
         </div>
       </div>
     );
   }
 
-  const isValid = selectedCouncil.length >= 2 && selectedChairman;
-
-  return (
-    <div className="model-selector">
-      <div className="selector-section">
-        <h4>Council Members ({selectedCouncil.length})</h4>
-        <p className="selector-help">Select 2+ models to participate in the council</p>
-
-        <ModelSearchBox
-          ref={searchInputRef}
-          value={searchQuery}
-          onChange={setSearchQuery}
-        />
-
-        <FilterChips
-          filters={filters}
-          curatedCount={curatedIds.size}
-          showCuratedFilter={true}
-          showContextFilter={true}
-          showProviderChips={true}
-          allProviders={allProviders}
-        />
-
-        <div className="filter-results-row">
-          <div className="filter-results-count">
-            {filteredCount} of {totalCount} models
+  // ── Error state ────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div className="cc-modal-backdrop" onClick={onCancel}>
+        <div className="cc-modal-panel" onClick={(e) => e.stopPropagation()}>
+          <div className="ms-status-state ms-status-state--error">
+            {error}
+            <button onClick={refetch} className="ms-retry-btn">
+              Retry
+            </button>
           </div>
-          <button
-            className={`refresh-btn ${refreshing ? 'refreshing' : ''}`}
-            onClick={refresh}
-            disabled={refreshing}
-            title="Refresh models from OpenRouter"
-          >
-            <RefreshCw size={14} />
-            {refreshing ? 'Refreshing...' : 'Refresh'}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Main render ────────────────────────────────────────────────────────
+  return (
+    <div className="cc-modal-backdrop" onClick={onCancel}>
+      <div
+        className="cc-modal-panel"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Configure council"
+      >
+        {/* Header */}
+        <div className="cc-modal-header">
+          <div>
+            <div className="cc-modal-title">Configure council</div>
+            <div className="cc-modal-subtitle">
+              <span className="ms-count-num">{selectedCouncil.length}</span> models convened ·{' '}
+              <Crown
+                size={11}
+                style={{ verticalAlign: 'middle', marginBottom: 1 }}
+                aria-hidden="true"
+              />{' '}
+              marks the chairman
+            </div>
+          </div>
+          <button className="cc-modal-close" onClick={onCancel} aria-label="Close">
+            <X size={16} />
           </button>
         </div>
 
-        <ModelGroups
-          sortedProviders={sortedProviders}
-          groupedModels={groupedModels}
-          isExpanded={isExpanded}
-          onToggleProvider={toggleProvider}
-          isSelected={(id) => selectedCouncil.includes(id)}
-          onToggleModel={toggleCouncilMember}
-          variant="checkbox"
-          getSelectedCount={(provider) => selectedPerProvider[provider] || 0}
-        />
+        {/* Body */}
+        <div className="cc-modal-body ms-body">
+          <ModelSearchBox ref={searchInputRef} value={searchQuery} onChange={setSearchQuery} />
+
+          <FilterChips
+            filters={filters}
+            curatedCount={curatedIds.size}
+            showCuratedFilter={true}
+            showContextFilter={true}
+            showProviderChips={true}
+            allProviders={allProviders}
+          />
+
+          <div className="ms-filter-row">
+            <span className="ms-filter-count">
+              <span className="ms-count-num">{filteredCount}</span> of{' '}
+              <span className="ms-count-num">{totalCount}</span> models
+            </span>
+            <button
+              className={`ms-refresh-btn${refreshing ? ' ms-refresh-btn--spinning' : ''}`}
+              onClick={refresh}
+              disabled={refreshing}
+              title="Refresh models from OpenRouter"
+            >
+              <RefreshCw size={14} />
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+          </div>
+
+          <ModelGroups
+            sortedProviders={sortedProviders}
+            groupedModels={groupedModels}
+            isExpanded={isExpanded}
+            onToggleProvider={toggleProvider}
+            isSelected={(id) => selectedCouncil.includes(id)}
+            onToggleModel={toggleCouncilMember}
+            variant="council"
+            getSelectedCount={(provider) => selectedPerProvider[provider] || 0}
+            seatOf={seatOf}
+            isChairman={(id) => id === selectedChairman}
+            onSetChairman={onChairmanChange}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="cc-modal-footer">
+          <span className="ms-footer-count">
+            <span className="ms-count-num">{selectedCouncil.length}</span> of 10 selected
+          </span>
+          <div className="ms-footer-actions">
+            <button className="ms-cancel-btn" onClick={onCancel} disabled={saving}>
+              Cancel
+            </button>
+            <button className="ms-save-btn" onClick={handleSave} disabled={!isValid || saving}>
+              {saving ? 'Saving…' : 'Save council'}
+            </button>
+          </div>
+        </div>
       </div>
-
-      <div className="selector-section">
-        <h4>Chairman {selectedChairman ? '(1)' : ''}</h4>
-        <p className="selector-help">The model that synthesizes the final answer</p>
-
-        <ModelGroups
-          sortedProviders={sortedProviders}
-          groupedModels={groupedModels}
-          isExpanded={isChairmanExpanded}
-          onToggleProvider={toggleChairmanProvider}
-          isSelected={(id) => id === selectedChairman}
-          onToggleModel={onChairmanChange}
-          variant="radio"
-          radioName="chairman-model"
-          showContext={true}
-        />
-      </div>
-
-      <div className="selector-actions">
-        <button
-          className="cancel-btn"
-          onClick={onCancel}
-          disabled={saving}
-        >
-          Cancel
-        </button>
-        <button
-          className="save-btn"
-          onClick={handleSave}
-          disabled={!isValid || saving}
-        >
-          {saving ? 'Saving...' : 'Save Configuration'}
-        </button>
-      </div>
-
-      {!isValid && (
-        <p className="validation-warning">
-          {selectedCouncil.length < 2 && 'Select at least 2 council members. '}
-          {!selectedChairman && 'Select a chairman.'}
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/Round.css
+++ b/frontend/src/components/Round.css
@@ -2,25 +2,10 @@
 
 .round {
   margin-bottom: 1.5rem;
-  border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 8px;
-  background: var(--surface-color, #fff);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg-raised);
   overflow: hidden;
-}
-
-/* Round type accents */
-.round-responses {
-  --round-accent: var(--stage1-accent, #4a90e2);
-}
-
-.round-rankings {
-  --round-accent: var(--stage2-accent, #9c27b0);
-}
-
-.round-opening,
-.round-rebuttal,
-.round-closing {
-  --round-accent: var(--arena-accent, #2e7d32);
 }
 
 /* Header */
@@ -28,9 +13,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
-  background: color-mix(in srgb, var(--round-accent) 10%, transparent);
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  padding: 10px 14px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line);
 }
 
 .round-header.collapsible {
@@ -38,269 +23,329 @@
 }
 
 .round-header.collapsible:hover {
-  background: color-mix(in srgb, var(--round-accent) 15%, transparent);
+  background: var(--surface-hover);
 }
 
 .round-title-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 10px;
 }
 
 .round-number {
-  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--round-accent);
-  background: color-mix(in srgb, var(--round-accent) 15%, transparent);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
 }
 
 .round-title {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 15px;
   font-weight: 600;
-  color: var(--text-primary, #333);
+  color: var(--fg);
 }
 
 .round-cost {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  font-family: var(--font-mono, 'JetBrains Mono', monospace);
-  font-size: 0.6875rem;
+  gap: 3px;
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-weight: 500;
-  color: var(--color-gold-dark, #9A7F42);
-  background: color-mix(in srgb, var(--color-gold, #C4A35A) 15%, transparent);
-  padding: 2px 6px;
-  border-radius: 4px;
+  color: var(--fg-subtle);
+  background: var(--surface);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
   margin-left: auto;
 }
 
 .round-cost svg {
-  opacity: 0.7;
+  color: var(--fg-faint);
 }
 
 .collapse-toggle {
   background: none;
   border: none;
-  padding: 0.25rem;
+  padding: 4px;
   cursor: pointer;
-  color: var(--text-secondary, #666);
-  font-size: 0.875rem;
+  color: var(--fg-faint);
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--dur-micro) var(--ease-out);
+}
+
+.collapse-toggle:hover {
+  color: var(--fg-subtle);
 }
 
 /* Description text */
 .round-description {
-  padding: 0.75rem 1rem;
+  padding: 10px 14px;
   margin: 0;
-  font-size: 0.8125rem;
-  color: var(--text-secondary, #666);
-  background: var(--surface-secondary, #f8f9fa);
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fg-subtle);
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line);
 }
 
-/* Tabs */
-.tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.5rem 1rem;
-  background: var(--surface-secondary, #f8f9fa);
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+/* Tab bar — pad the .tabs container inside the round card */
+.round-tabs {
+  padding: 10px 10px 0 10px;
 }
 
-.tab {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.625rem;
-  border: 1px solid var(--border-color, #ddd);
-  border-radius: 4px;
-  background: var(--surface-color, #fff);
-  font-size: 0.75rem;
-  color: var(--text-primary, #333);
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+/* Seat dot inside tabs */
+.tab-seat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  transition: opacity var(--dur-micro) var(--ease-out);
 }
 
-.tab:hover {
-  border-color: var(--round-accent);
-  background: color-mix(in srgb, var(--round-accent) 5%, var(--surface-color, #fff));
-}
-
-.tab.active {
-  background: var(--round-accent);
-  color: white;
-  border-color: var(--round-accent);
-}
-
+/* Reasoning indicator (Brain icon) inside tab */
 .reasoning-indicator {
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning);
+  flex: none;
 }
 
-.tab.active .reasoning-indicator {
-  color: white;
-}
-
-/* Tab content */
-.tab-content {
-  padding: 1rem;
-}
-
-.tab-content-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.75rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border-color, #eee);
-}
-
+/* Model info group in tab-content-header */
 .model-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 10px;
 }
 
-.participant-label {
-  font-weight: 600;
-  color: var(--round-accent);
+.model-name-group {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
 }
 
 .model-name {
-  font-size: 0.8125rem;
-  color: var(--text-secondary, #666);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
 }
 
-.copy-btn {
+.model-anon-id {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-faint);
+}
+
+.tab-header-actions {
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.375rem;
-  border: 1px solid var(--border-color, #ddd);
-  border-radius: 4px;
-  background: var(--surface-color, #fff);
-  color: var(--text-secondary, #666);
-  cursor: pointer;
-  transition: border-color 0.15s ease, color 0.15s ease;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
-.copy-btn:hover {
-  border-color: var(--round-accent);
-  color: var(--round-accent);
+/* Stance chip — shown only when response data includes a stance */
+.stance-chip {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  letter-spacing: 0.02em;
 }
 
-/* Reasoning section */
+/* Reasoning section (council + synthesis) */
 .reasoning-section {
-  margin-bottom: 0.75rem;
-  border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 6px;
+  margin-bottom: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .reasoning-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   width: 100%;
-  padding: 0.5rem 0.75rem;
-  background: color-mix(in srgb, var(--warning-color, #f59e0b) 10%, transparent);
+  padding: 8px 12px;
+  background: var(--bg-sunken);
   border: none;
   cursor: pointer;
-  font-size: 0.8125rem;
-  color: var(--text-primary, #333);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-subtle);
+  text-align: left;
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
 .reasoning-toggle:hover {
-  background: color-mix(in srgb, var(--warning-color, #f59e0b) 15%, transparent);
+  background: var(--surface-hover);
+}
+
+.reasoning-toggle svg {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .reasoning-content {
-  padding: 0.75rem;
-  background: var(--surface-secondary, #f8f9fa);
-  font-size: 0.8125rem;
-  color: var(--text-secondary, #555);
-  border-top: 1px solid var(--border-color, #e0e0e0);
-}
-
-/* Response content */
-.response-content {
+  padding: 12px;
+  background: var(--bg-sunken);
+  font-size: 13px;
+  color: var(--fg-subtle);
   line-height: 1.6;
+  border-top: 1px solid var(--line);
 }
 
-/* Parsed ranking */
+/* Response prose */
+.response-content {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+}
+
+/* Per-response metrics row */
+.response-metrics {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 16px;
+  padding-top: 13px;
+  border-top: 1px solid var(--line);
+}
+
+.response-metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.metric-glyph {
+  color: var(--fg-faint);
+  flex: none;
+}
+
+.metric-val {
+  color: var(--fg-subtle);
+}
+
+/* Extracted ranking (peer-review round) */
 .parsed-ranking {
-  margin-top: 1rem;
-  padding: 0.75rem;
-  background: var(--surface-secondary, #f8f9fa);
-  border-radius: 6px;
-  font-size: 0.8125rem;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--bg-sunken);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--fg-subtle);
 }
 
 .parsed-ranking ol {
-  margin: 0.5rem 0 0 1.25rem;
+  margin: 8px 0 0 1.25rem;
   padding: 0;
 }
 
 .parsed-ranking li {
-  margin-bottom: 0.25rem;
+  margin-bottom: 4px;
 }
 
-/* Aggregate rankings */
+/* ── Aggregate peer standings ─────────────────────────────────────────────── */
 .aggregate-rankings {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  padding: 18px 20px 20px;
+  border-top: 1px solid var(--line);
 }
 
-.aggregate-rankings h4 {
-  margin: 0 0 0.5rem 0;
-  font-size: 0.875rem;
-  color: var(--text-primary, #333);
+.aggregate-rankings-title {
+  margin: 0 0 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
 }
 
-.aggregate-rankings .description {
-  margin: 0 0 0.75rem 0;
-  font-size: 0.75rem;
-  color: var(--text-secondary, #666);
+.aggregate-rankings-desc {
+  margin: 0 0 18px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fg-subtle);
 }
 
 .aggregate-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 11px;
 }
 
 .aggregate-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--surface-secondary, #f8f9fa);
-  border-radius: 6px;
-  font-size: 0.8125rem;
+  gap: 13px;
 }
 
 .rank-position {
+  font-family: var(--font-mono);
+  font-size: 13px;
   font-weight: 700;
-  color: var(--round-accent);
-  min-width: 2rem;
+  color: var(--fg-faint);
+  width: 22px;
+  flex: none;
+}
+
+.rank-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
 }
 
 .rank-model {
+  width: 140px;
+  flex: none;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rank-bar-track {
   flex: 1;
-  font-weight: 500;
+  height: 8px;
+  background: var(--bg-sunken);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.rank-bar-fill {
+  height: 100%;
+  border-radius: 5px;
+  transform-origin: left;
+  animation: ccBar var(--dur-deliberate) var(--ease-out) both;
 }
 
 .rank-score {
-  color: var(--text-secondary, #666);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg);
+  width: 38px;
+  text-align: right;
+  flex: none;
 }
 
-.rank-count {
-  font-size: 0.75rem;
-  color: var(--text-muted, #999);
+.rank-votes {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-faint);
+  width: 54px;
+  text-align: right;
+  flex: none;
 }
 
 /* Collapsed state */
@@ -308,14 +353,54 @@
   border-bottom: none;
 }
 
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  .round {
-    --surface-color: #1a1a1a;
-    --surface-secondary: #252525;
-    --border-color: #333;
-    --text-primary: #e0e0e0;
-    --text-secondary: #aaa;
-    --text-muted: #777;
-  }
+/* ── Arena round: 2-column debate grid ───────────────────────────────────── */
+.arena-round-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+  padding: 14px;
+}
+
+.arena-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  /* border-top color is seat-specific via inline style */
+}
+
+.arena-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.arena-seat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.arena-card-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.arena-card-role {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-left: auto;
+  /* color is seat-specific via inline style */
+}
+
+.arena-card-body {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--fg-muted);
 }

--- a/frontend/src/components/Round.jsx
+++ b/frontend/src/components/Round.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronDown, ChevronRight, Brain, Copy, Check, DollarSign } from 'lucide-react';
+import { ChevronDown, ChevronRight, Brain, Copy, Check, RotateCw, Hash, Coins } from 'lucide-react';
 import MetricsDisplay from './MetricsDisplay';
-import { formatCost, getReasoningText } from '../lib/formatting';
+import { SeatAvatar } from './ui';
+import { useSeatColors } from '../hooks/useSeatColors';
+import { formatCost, formatLatency, formatTokens, getReasoningText } from '../lib/formatting';
 import {
   deAnonymizeText,
   getResponseContent,
@@ -15,11 +17,11 @@ import './Round.css';
 
 // Round type labels for display
 const ROUND_TYPE_LABELS = {
-  responses: 'Individual Responses',
-  rankings: 'Peer Rankings',
-  opening: 'Opening Statements',
-  rebuttal: 'Rebuttals',
-  closing: 'Closing Arguments',
+  responses: 'First opinions',
+  rankings: 'Peer review',
+  opening: 'Opening',
+  rebuttal: 'Rebuttal',
+  closing: 'Closing',
 };
 
 export default function Round({
@@ -33,6 +35,7 @@ export default function Round({
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
   const [reasoningExpanded, setReasoningExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const { seatOf } = useSeatColors();
 
   if (!round || !round.responses || round.responses.length === 0) {
     return null;
@@ -59,28 +62,76 @@ export default function Round({
     }
   };
 
-  return (
-    <div className={`round round-${roundType} ${isCollapsed ? 'collapsed' : ''}`}>
-      <div
-        className={`round-header ${isCollapsible ? 'collapsible' : ''}`}
-        onClick={isCollapsible ? () => setIsCollapsed(!isCollapsed) : undefined}
-      >
-        <div className="round-title-row">
-          {round.round_number && <span className="round-number">Round {round.round_number}</span>}
-          <h3 className="round-title">{roundLabel}</h3>
-          {roundCost > 0 && (
-            <span className="round-cost" title="Cost for this round">
-              <DollarSign size={12} />
-              {formatCost(roundCost)}
-            </span>
-          )}
-        </div>
-        {isCollapsible && (
-          <button className="collapse-toggle" aria-label={isCollapsed ? 'Expand' : 'Collapse'}>
-            {isCollapsed ? '▶' : '▼'}
-          </button>
+  // Round header — shared by both paths
+  const roundHeader = (
+    <div
+      className={`round-header ${isCollapsible ? 'collapsible' : ''}`}
+      onClick={isCollapsible ? () => setIsCollapsed(!isCollapsed) : undefined}
+    >
+      <div className="round-title-row">
+        {round.round_number && <span className="round-number">Round {round.round_number}</span>}
+        <h3 className="round-title">{roundLabel}</h3>
+        {roundCost > 0 && (
+          <span className="round-cost" title="Cost for this round">
+            <Coins size={11} strokeWidth={2} />
+            {formatCost(roundCost)}
+          </span>
         )}
       </div>
+      {isCollapsible && (
+        <button className="collapse-toggle" aria-label={isCollapsed ? 'Expand' : 'Collapse'}>
+          {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+        </button>
+      )}
+    </div>
+  );
+
+  // Arena rounds render as a 2-column debate grid instead of tabs
+  if (isArenaRound) {
+    return (
+      <div className={`round round-${roundType} ${isCollapsed ? 'collapsed' : ''}`}>
+        {roundHeader}
+        {!isCollapsed && (
+          <div className="arena-round-grid">
+            {round.responses.map((resp, index) => {
+              const modelId =
+                resp.model || (participantMapping && participantMapping[resp.participant]) || null;
+              const seat = seatOf(modelId);
+              const modelName = getModelDisplayName(resp, participantMapping);
+              const shortName = modelName?.split('/')[1] || modelName || resp.participant;
+              const role = index === 0 ? 'FOR' : 'AGAINST';
+
+              return (
+                <div
+                  key={index}
+                  className="arena-card"
+                  style={{ borderTop: `3px solid ${seat.color}` }}
+                >
+                  <div className="arena-card-header">
+                    <span className="arena-seat-dot" style={{ background: seat.color }} />
+                    <span className="arena-card-name">{shortName}</span>
+                    <span className="arena-card-role" style={{ color: seat.color }}>
+                      {role}
+                    </span>
+                  </div>
+                  <div className="arena-card-body markdown-content">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {getResponseContent(resp)}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Council rounds (Stage 1 responses, Stage 2 rankings) — tab layout
+  return (
+    <div className={`round round-${roundType} ${isCollapsed ? 'collapsed' : ''}`}>
+      {roundHeader}
 
       {!isCollapsed && (
         <>
@@ -92,42 +143,80 @@ export default function Round({
             </p>
           )}
 
-          <div className="tabs" role="tablist" aria-label={`${roundLabel} tabs`}>
-            {round.responses.map((resp, index) => (
-              <button
-                key={index}
-                role="tab"
-                aria-selected={activeTab === index}
-                tabIndex={activeTab === index ? 0 : -1}
-                className={`tab ${activeTab === index ? 'active' : ''}`}
-                onClick={() => setActiveTab(index)}
-                onKeyDown={(e) => {
-                  if (e.key === 'ArrowRight') {
-                    setActiveTab((activeTab + 1) % round.responses.length);
-                  } else if (e.key === 'ArrowLeft') {
-                    setActiveTab((activeTab - 1 + round.responses.length) % round.responses.length);
-                  }
-                }}
-              >
-                {getTabLabel(resp, isArenaRound)}
-                {resp.reasoning_details && (
-                  <Brain size={12} className="reasoning-indicator" aria-hidden="true" />
-                )}
-              </button>
-            ))}
+          {/* Tab bar — one tab per model, seat dot + short name */}
+          <div className="tabs round-tabs" role="tablist" aria-label={`${roundLabel} tabs`}>
+            {round.responses.map((resp, index) => {
+              const seat = seatOf(resp.model);
+              const isActive = activeTab === index;
+              return (
+                <button
+                  key={index}
+                  role="tab"
+                  aria-selected={isActive}
+                  tabIndex={isActive ? 0 : -1}
+                  className={`tab ${isActive ? 'active' : ''}`}
+                  style={isActive ? { '--tab-accent-color': seat.color } : undefined}
+                  onClick={() => setActiveTab(index)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowRight') {
+                      setActiveTab((activeTab + 1) % round.responses.length);
+                    } else if (e.key === 'ArrowLeft') {
+                      setActiveTab(
+                        (activeTab - 1 + round.responses.length) % round.responses.length
+                      );
+                    }
+                  }}
+                >
+                  <span
+                    className="tab-seat-dot"
+                    style={{ background: seat.color, opacity: isActive ? 1 : 0.55 }}
+                  />
+                  {getTabLabel(resp, false)}
+                  {resp.reasoning_details && (
+                    <Brain size={12} className="reasoning-indicator" aria-hidden="true" />
+                  )}
+                </button>
+              );
+            })}
           </div>
 
+          {/* Active tab panel */}
           <div className="tab-content" role="tabpanel">
             <div className="tab-content-header">
               <div className="model-info">
-                {isArenaRound && (
-                  <span className="participant-label">{currentResponse.participant}</span>
-                )}
-                <span className="model-name">{getModelDisplayName(currentResponse, participantMapping)}</span>
+                <SeatAvatar
+                  color={seatOf(currentResponse.model).color}
+                  name={getModelDisplayName(currentResponse, participantMapping)}
+                  size={28}
+                />
+                <div className="model-name-group">
+                  <span className="model-name">
+                    {(() => {
+                      const full = getModelDisplayName(currentResponse, participantMapping);
+                      return full?.split('/')[1] || full;
+                    })()}
+                  </span>
+                  {currentResponse.participant && (
+                    <span className="model-anon-id">{currentResponse.participant}</span>
+                  )}
+                </div>
               </div>
-              <button className="copy-btn" onClick={handleCopy} title="Copy response">
-                {copied ? <Check size={14} /> : <Copy size={14} />}
-              </button>
+              <div className="tab-header-actions">
+                {currentResponse.stance && (
+                  <span
+                    className="stance-chip"
+                    style={{
+                      color: seatOf(currentResponse.model).color,
+                      background: seatOf(currentResponse.model).soft,
+                    }}
+                  >
+                    {currentResponse.stance}
+                  </span>
+                )}
+                <button className="copy-btn" onClick={handleCopy} title="Copy response">
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                </button>
+              </div>
             </div>
 
             {hasReasoning && (
@@ -156,7 +245,7 @@ export default function Round({
               </ReactMarkdown>
             </div>
 
-            {/* Parsed ranking for rankings round */}
+            {/* Extracted ranking for peer-review round */}
             {isRankings && currentResponse.parsed_ranking?.length > 0 && (
               <div className="parsed-ranking">
                 <strong>Extracted Ranking:</strong>
@@ -171,24 +260,65 @@ export default function Round({
                 </ol>
               </div>
             )}
+
+            {/* Per-response metrics row */}
+            {currentResponse.metrics && (
+              <div className="response-metrics">
+                {currentResponse.metrics.latency_ms != null && (
+                  <span className="response-metric">
+                    <RotateCw size={11} strokeWidth={2} className="metric-glyph" />
+                    <span className="metric-val">
+                      {formatLatency(currentResponse.metrics.latency_ms)}
+                    </span>
+                  </span>
+                )}
+                {currentResponse.metrics.tokens != null && (
+                  <span className="response-metric">
+                    <Hash size={11} strokeWidth={2} className="metric-glyph" />
+                    <span className="metric-val">
+                      {formatTokens(currentResponse.metrics.tokens)}
+                    </span>
+                  </span>
+                )}
+                {formatCost(currentResponse.metrics.cost) && (
+                  <span className="response-metric">
+                    <Coins size={11} strokeWidth={2} className="metric-glyph" />
+                    <span className="metric-val">{formatCost(currentResponse.metrics.cost)}</span>
+                  </span>
+                )}
+              </div>
+            )}
           </div>
 
-          {/* Aggregate rankings for rankings round */}
+          {/* Aggregate peer standings for rankings round */}
           {isRankings && round.metadata?.aggregate_rankings?.length > 0 && (
             <div className="aggregate-rankings">
-              <h4>Aggregate Rankings (Street Cred)</h4>
-              <p className="description">
-                Combined results across all peer evaluations (lower score is better):
+              <h4 className="aggregate-rankings-title">Peer standings</h4>
+              <p className="aggregate-rankings-desc">
+                Aggregate rank across all ballots — lower is better.
               </p>
               <div className="aggregate-list">
-                {round.metadata.aggregate_rankings.map((agg, index) => (
-                  <div key={index} className="aggregate-item">
-                    <span className="rank-position">#{index + 1}</span>
-                    <span className="rank-model">{agg.model.split('/')[1] || agg.model}</span>
-                    <span className="rank-score">Avg: {agg.average_rank.toFixed(2)}</span>
-                    <span className="rank-count">({agg.rankings_count} votes)</span>
-                  </div>
-                ))}
+                {round.metadata.aggregate_rankings.map((agg, index) => {
+                  const seat = seatOf(agg.model);
+                  const N = round.metadata.aggregate_rankings.length;
+                  const barWidth =
+                    N > 1 ? Math.max(8, ((N - agg.average_rank + 1) / N) * 100) : 100;
+                  return (
+                    <div key={index} className="aggregate-item">
+                      <span className="rank-position">#{index + 1}</span>
+                      <span className="rank-dot" style={{ background: seat.color }} />
+                      <span className="rank-model">{agg.model.split('/')[1] || agg.model}</span>
+                      <div className="rank-bar-track">
+                        <div
+                          className="rank-bar-fill"
+                          style={{ width: `${barWidth}%`, background: seat.color }}
+                        />
+                      </div>
+                      <span className="rank-score">{agg.average_rank.toFixed(2)}</span>
+                      <span className="rank-votes">{agg.rankings_count} votes</span>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/frontend/src/components/Round.jsx
+++ b/frontend/src/components/Round.jsx
@@ -49,6 +49,7 @@ export default function Round({
   const roundCost = getRoundCost(round);
 
   const currentResponse = round.responses[activeTab];
+  const currentSeat = seatOf(currentResponse.model);
   const reasoningText = getReasoningText(currentResponse.reasoning_details);
   const hasReasoning = !!reasoningText;
 
@@ -150,7 +151,7 @@ export default function Round({
               const isActive = activeTab === index;
               return (
                 <button
-                  key={index}
+                  key={resp.model ?? index}
                   role="tab"
                   aria-selected={isActive}
                   tabIndex={isActive ? 0 : -1}
@@ -185,7 +186,7 @@ export default function Round({
             <div className="tab-content-header">
               <div className="model-info">
                 <SeatAvatar
-                  color={seatOf(currentResponse.model).color}
+                  color={currentSeat.color}
                   name={getModelDisplayName(currentResponse, participantMapping)}
                   size={28}
                 />
@@ -206,8 +207,8 @@ export default function Round({
                   <span
                     className="stance-chip"
                     style={{
-                      color: seatOf(currentResponse.model).color,
-                      background: seatOf(currentResponse.model).soft,
+                      color: currentSeat.color,
+                      background: currentSeat.soft,
                     }}
                   >
                     {currentResponse.stance}
@@ -304,7 +305,7 @@ export default function Round({
                   const barWidth =
                     N > 1 ? Math.max(8, ((N - agg.average_rank + 1) / N) * 100) : 100;
                   return (
-                    <div key={index} className="aggregate-item">
+                    <div key={agg.model} className="aggregate-item">
                       <span className="rank-position">#{index + 1}</span>
                       <span className="rank-dot" style={{ background: seat.color }} />
                       <span className="rank-model">{agg.model.split('/')[1] || agg.model}</span>

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,45 +1,33 @@
-/* Sidebar - Navigation Panel */
+/* ===== Sidebar — 268px, sunken background, right border ===== */
 .sidebar {
-  width: 280px;
-  background: linear-gradient(180deg, var(--color-sage-light) 0%, var(--color-sage) 100%);
-  border-right: 1px solid var(--color-border);
+  width: 268px;
+  background: var(--bg-sunken);
+  border-right: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   height: 100vh;
   position: relative;
 }
 
-/* Subtle decorative line at top */
-.sidebar::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--color-burgundy), var(--color-burgundy-light), var(--color-burgundy));
-}
-
-.sidebar-header {
-  padding: var(--space-lg);
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
-}
-
-.sidebar-title-row {
+/* ===== Brand lockup ===== */
+.sidebar-brand {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--space-md);
+  gap: 11px;
+  padding: 19px 18px 15px;
 }
 
-.sidebar-header h1 {
-  font-family: var(--font-display);
-  font-size: 1.375rem;
+.sidebar-wordmark {
+  flex: 1;
+  font-family: var(--font-head);
+  font-size: 17.5px;
   font-weight: 600;
-  margin: 0;
-  color: var(--color-text-primary);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
+  color: var(--fg);
+}
+
+.sidebar-wordmark-dim {
+  color: var(--fg-faint);
 }
 
 .sidebar-close-btn {
@@ -48,14 +36,22 @@
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
+  color: var(--fg-faint);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
+  flex-shrink: 0;
 }
 
 .sidebar-close-btn:hover {
-  background: var(--color-surface);
-  color: var(--color-burgundy);
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.sidebar-close-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
 }
 
 @media (max-width: 768px) {
@@ -66,252 +62,305 @@
   }
 }
 
-/* User Info Display */
+/* ===== CTA section ===== */
+.sidebar-cta-section {
+  padding: 0 14px 12px;
+}
+
 .user-info {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
-  margin-bottom: var(--space-md);
-  background: var(--color-surface);
+  margin-bottom: var(--space-sm);
+  background: var(--surface);
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid var(--line);
 }
 
 .user-avatar {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-burgundy);
-  color: #fff;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  font-family: var(--font-mono);
   font-size: 0.8125rem;
-  font-weight: 600;
-  border-radius: 50%;
+  font-weight: 700;
+  border-radius: 7px;
   flex-shrink: 0;
 }
 
 .user-name {
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--color-text-primary);
+  color: var(--fg);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.new-conversation-btn {
+/* Solid ember CTA — the single most prominent action */
+.new-deliberation-btn {
   width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-burgundy);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
   border: none;
-  border-radius: var(--radius-md);
-  color: #fff;
+  border-radius: 9px;
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
   cursor: pointer;
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: background var(--transition-medium), box-shadow var(--transition-medium), transform var(--transition-medium);
-  box-shadow: var(--shadow-subtle);
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    box-shadow var(--dur-micro) var(--ease-out);
+}
+
+.new-deliberation-btn:hover {
+  background: var(--accent-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.new-deliberation-btn:active {
+  transform: scale(0.98);
+}
+
+.new-deliberation-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
+/* ===== Mode segmented control ===== */
+.sidebar-mode-section {
+  padding: 0 14px 14px;
+}
+
+/* 2-button pill in a --surface track */
+.mode-control {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-sm);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 3px;
+  gap: 3px;
 }
 
-.new-conversation-btn:hover {
-  background: var(--color-burgundy-dark);
-  box-shadow: var(--shadow-medium);
-  transform: translateY(-1px);
-}
-
-.new-conversation-btn:active {
-  transform: translateY(0);
-}
-
-.sidebar-views {
-  display: flex;
-  gap: var(--space-xs);
-  margin-top: var(--space-md);
-}
-
-.sidebar-view-btn {
+.mode-btn {
   flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-sm);
+  padding: 7px 0;
+  border: none;
+  border-radius: 7px;
   background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
+  color: var(--fg-subtle);
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.sidebar-view-btn:hover {
-  background: var(--color-surface);
-  color: var(--color-text-primary);
+/* Active: accent-soft bg + accent text + 600 — soft tint, NOT solid fill */
+.mode-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
 }
 
-.sidebar-view-btn.active {
-  background: var(--color-burgundy);
-  border-color: var(--color-burgundy);
-  color: #fff;
+.mode-btn:not(.active):hover {
+  color: var(--fg);
 }
 
+.mode-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
+/* ===== Section label ===== */
+.sidebar-section-label {
+  padding: 4px 18px 6px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+/* ===== Conversation list ===== */
 .conversation-list {
   flex: 1;
   overflow-y: auto;
-  padding: var(--space-sm);
+  padding: 0 10px;
 }
 
 .no-conversations {
   padding: var(--space-xl);
   text-align: center;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   font-size: 0.875rem;
-  font-style: italic;
+  font-family: var(--font-display);
 }
 
+/* ===== Conversation item ===== */
 .conversation-item {
-  padding: var(--space-md);
-  margin-bottom: var(--space-xs);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  border: 1px solid transparent;
-  background: transparent;
+  width: 100%;
   display: flex;
   align-items: flex-start;
   gap: var(--space-sm);
+  flex-direction: row;
+  padding: 9px 10px;
+  margin-bottom: 2px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  cursor: pointer;
   position: relative;
-  overflow: hidden;
   transition:
-    background 0.2s ease,
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-/* Left accent indicator */
-.conversation-item::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 3px;
-  background: var(--color-burgundy);
-  transform: scaleY(0);
-  transform-origin: center;
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    box-shadow var(--dur-micro) var(--ease-out);
 }
 
 .conversation-item:hover {
-  background: var(--color-surface);
-  border-color: var(--color-border-light);
+  background: var(--surface);
 }
 
 .conversation-item:active {
-  transform: scale(0.99);
+  transform: scale(0.98);
 }
 
 .conversation-item:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
+/* Selected: surface bg + line border + shadow */
 .conversation-item.active {
-  background: var(--color-surface-elevated);
-  border-color: var(--color-burgundy);
-  box-shadow: var(--shadow-subtle);
-}
-
-.conversation-item.active::before {
-  transform: scaleY(1);
+  background: var(--surface);
+  border-color: var(--line);
+  box-shadow: var(--shadow-sm);
 }
 
 .conversation-item.deleting {
-  background: rgba(220, 53, 69, 0.1);
-  border-color: rgba(220, 53, 69, 0.3);
-  animation: deleteShake 0.4s ease;
-  -webkit-backface-visibility: hidden;
+  background: var(--danger-soft);
+  border-color: var(--danger);
 }
 
-@keyframes deleteShake {
-  0%, 100% { transform: translateX(0); }
-  20% { transform: translateX(-4px); }
-  40% { transform: translateX(4px); }
-  60% { transform: translateX(-2px); }
-  80% { transform: translateX(2px); }
-}
-
+/* Two-line content */
 .conversation-content {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* Line 1: seat dot + title */
+.conversation-row-1 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+/* 9px seat-colored dot */
+.conversation-seat-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+  /* background set via inline style from seatOf() */
 }
 
 .conversation-title {
-  font-family: var(--font-body);
+  flex: 1;
+  font-family: var(--font-display);
+  font-size: 13px;
   font-weight: 500;
-  color: var(--color-text-primary);
-  font-size: 0.9375rem;
-  margin-bottom: var(--space-xs);
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  color: var(--fg);
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
 }
 
-.conversation-item.active .conversation-title {
-  color: var(--color-burgundy);
+/* Line 2: mode · relative time */
+.conversation-row-2 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  /* indent to align with title (9px dot + 8px gap = 17px) */
+  padding-left: 17px;
 }
 
-.conversation-meta {
-  color: var(--color-text-muted);
-  font-size: 0.75rem;
+.conversation-mode {
+  font-size: 10px;
   font-family: var(--font-mono);
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-/* Conversation Actions */
+.conversation-sep {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+}
+
+.conversation-time {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+}
+
+/* ===== Conversation actions (hover reveal) ===== */
 .conversation-actions {
   display: flex;
   gap: 2px;
   opacity: 0;
-  transition: opacity var(--transition-fast);
+  transition: opacity var(--dur-micro) var(--ease-out);
   flex-shrink: 0;
 }
 
-.conversation-item:hover .conversation-actions {
+.conversation-item:hover .conversation-actions,
+.conversation-item:focus-within .conversation-actions {
   opacity: 1;
 }
 
 .action-btn {
-  padding: 4px 6px;
+  padding: 4px 5px;
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 0.75rem;
-  opacity: 0.6;
-  transition: opacity var(--transition-fast), background var(--transition-fast);
+  color: var(--fg-faint);
+  display: flex;
+  align-items: center;
+  transition:
+    color var(--dur-micro) var(--ease-out),
+    background var(--dur-micro) var(--ease-out);
 }
 
 .action-btn:hover {
-  opacity: 1;
-  background: var(--color-surface);
+  color: var(--fg);
+  background: var(--surface-hover);
 }
 
 .action-btn.action-delete:hover {
-  background: rgba(220, 53, 69, 0.15);
+  color: var(--danger);
+  background: var(--danger-soft);
 }
 
-/* Export Menu */
+/* Export menu */
 .export-menu-container {
   position: relative;
 }
@@ -322,10 +371,10 @@
   right: 0;
   z-index: 100;
   min-width: 160px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-md);
   padding: var(--space-xs);
   margin-top: 2px;
 }
@@ -334,39 +383,39 @@
   display: block;
   width: 100%;
   padding: var(--space-sm) var(--space-md);
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: 0.8125rem;
-  color: var(--color-text-primary);
+  color: var(--fg);
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
   text-align: left;
-  transition: background var(--transition-fast);
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
 .export-menu-item:hover {
-  background: var(--color-cream);
+  background: var(--surface-hover);
 }
 
-/* Rename Input */
+/* Rename input */
 .rename-input {
   width: 100%;
   padding: var(--space-sm);
-  font-family: var(--font-body);
-  font-size: 0.9375rem;
-  border: 1px solid var(--color-burgundy);
+  font-family: var(--font-display);
+  font-size: 13px;
+  border: 1px solid var(--accent);
   border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-text-primary);
+  background: var(--bg-raised);
+  color: var(--fg);
   outline: none;
 }
 
 .rename-input:focus {
-  box-shadow: 0 0 0 2px rgba(134, 70, 88, 0.2);
+  box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
-/* Delete Confirmation */
+/* Delete confirmation */
 .delete-confirm {
   display: flex;
   align-items: center;
@@ -376,10 +425,10 @@
 }
 
 .delete-confirm-text {
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: 0.875rem;
   font-weight: 500;
-  color: #dc3545;
+  color: var(--danger);
 }
 
 .delete-confirm-actions {
@@ -389,153 +438,141 @@
 
 .confirm-btn {
   padding: var(--space-xs) var(--space-sm);
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: 0.75rem;
   font-weight: 500;
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition: opacity var(--dur-micro) var(--ease-out);
 }
 
 .confirm-yes {
-  background: #dc3545;
+  background: var(--danger);
   color: #fff;
 }
 
 .confirm-yes:hover {
-  background: #c82333;
+  opacity: 0.85;
 }
 
 .confirm-no {
-  background: var(--color-sage);
-  color: var(--color-text-primary);
+  background: var(--surface);
+  color: var(--fg);
+  border: 1px solid var(--line);
 }
 
 .confirm-no:hover {
-  background: var(--color-sage-light);
+  background: var(--surface-hover);
 }
 
-/* Council Panel - styles moved to sidebar/CouncilDisplay.css */
+/* ===== Sidebar footer ===== */
+.sidebar-footer {
+  border-top: 1px solid var(--line);
+  padding: 8px 10px;
+}
 
-/* Config Modal */
-.config-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(42, 37, 32, 0.6);
+/* Footer nav rows — Standings + Models */
+.sidebar-nav-row {
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fadeIn 0.2s ease-out;
-  -webkit-backface-visibility: hidden;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-.config-modal {
-  background: var(--color-cream);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-elevated), 0 0 0 1px var(--color-border);
-  width: 95%;
-  max-width: 900px;
-  max-height: 90vh;
-  min-height: 600px;
-  overflow: hidden;
-  animation: modalSlideIn 0.3s ease-out;
-  -webkit-backface-visibility: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-@keyframes modalSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(-20px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.config-modal-header {
-  padding: var(--space-lg) var(--space-xl);
-  border-bottom: 1px solid var(--color-border);
-  background: linear-gradient(180deg, var(--color-ivory) 0%, var(--color-cream) 100%);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.config-modal-header h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.modal-close-btn {
-  padding: var(--space-xs);
+  gap: 10px;
+  padding: 8px 10px;
   background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: var(--fg-muted);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  text-align: left;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.modal-close-btn:hover {
-  background: var(--color-surface);
-  color: var(--color-burgundy);
+.sidebar-nav-row:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
 }
 
-.modal-close-btn:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+/* Active state: surface bg + line border */
+.sidebar-nav-row.active {
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.sidebar-nav-row:focus-visible {
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
-/* Sidebar Footer */
-.sidebar-footer {
+/* Right-aligned live model count in Models row */
+.sidebar-model-count {
+  margin-left: auto;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+}
+
+/* ===== Status row: sync dot + theme chip ===== */
+.sidebar-status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-sm) var(--space-md);
-  border-top: 1px solid var(--color-border);
+  padding: 8px 10px 4px;
 }
 
-.theme-toggle {
+.sidebar-sync {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  gap: 7px;
+}
+
+/* Success dot */
+.sidebar-sync-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--success);
+  flex: none;
+}
+
+.sidebar-sync-text {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--fg-subtle);
+}
+
+/* Theme toggle chip — surface + line, mono 11px */
+.sidebar-theme-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
-.theme-toggle:hover {
-  background: var(--color-surface);
-  border-color: var(--color-border-light);
-  color: var(--color-text-primary);
+.sidebar-theme-chip:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
 }
 
-.theme-toggle:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+.sidebar-theme-chip:focus-visible {
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -449,7 +449,7 @@
 
 .confirm-yes {
   background: var(--danger);
-  color: #fff;
+  color: var(--fg-on-accent);
 }
 
 .confirm-yes:hover {

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -19,7 +19,7 @@ import {
 } from '../hooks/queries';
 import { api } from '../api';
 
-export default function Sidebar({ onSelectConversation, onNewConversation }) {
+export default function Sidebar({ onSelectConversation, onNewConversation, isLoading = false }) {
   const { data: conversations = [] } = useConversations();
   const currentConversationId = useUIStore((s) => s.currentConversationId);
   const { data: config } = useConfig();
@@ -57,10 +57,7 @@ export default function Sidebar({ onSelectConversation, onNewConversation }) {
     firstElement?.focus();
 
     const handleKeyDown = (e) => {
-      if (e.key === 'Escape') {
-        setShowConfigUI(false);
-        return;
-      }
+      // Escape-to-close is owned by ModelSelector itself; trap Tab here.
       if (e.key === 'Tab') {
         if (e.shiftKey && document.activeElement === firstElement) {
           e.preventDefault();
@@ -165,6 +162,7 @@ export default function Sidebar({ onSelectConversation, onNewConversation }) {
             className={`mode-btn ${mode === 'council' ? 'active' : ''}`}
             onClick={() => setMode('council')}
             aria-pressed={mode === 'council'}
+            disabled={isLoading}
           >
             Council
           </button>
@@ -173,6 +171,7 @@ export default function Sidebar({ onSelectConversation, onNewConversation }) {
             className={`mode-btn ${mode === 'arena' ? 'active' : ''}`}
             onClick={() => setMode('arena')}
             aria-pressed={mode === 'arena'}
+            disabled={isLoading}
           >
             Arena
           </button>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -148,7 +148,7 @@ export default function Sidebar({ onSelectConversation, onNewConversation, isLoa
           </div>
         )}
         {/* Solid ember CTA — single most prominent action */}
-        <button className="new-deliberation-btn" onClick={onNewConversation}>
+        <button type="button" className="new-deliberation-btn" onClick={onNewConversation}>
           <Plus size={14} aria-hidden="true" />
           New deliberation
         </button>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,29 +1,36 @@
 import { useState, useEffect, useRef } from 'react';
-import { Moon, Sun, Monitor, X, MessageSquare, Trophy } from 'lucide-react';
+import { Moon, Sun, Monitor, X, Plus, BarChart3, Settings } from 'lucide-react';
 import './Sidebar.css';
 import { ConversationItem, CouncilDisplay } from './sidebar/index.js';
 import ModelSelector from './ModelSelector';
 import ModelCuration from './ModelCuration';
 import VersionInfo from './VersionInfo';
+import { BrandMark } from './ui';
 import { useTheme } from '../hooks';
 import { getUserInitial, getUserDisplayName, getThemeLabel } from '../lib/sidebarUtils';
 import { useUIStore } from '../stores/uiStore';
-import { useConfig, useUserInfo, useConversations, useDeleteConversation, useRenameConversation, useUpdateConfig } from '../hooks/queries';
+import {
+  useConfig,
+  useUserInfo,
+  useConversations,
+  useDeleteConversation,
+  useRenameConversation,
+  useUpdateConfig,
+} from '../hooks/queries';
 import { api } from '../api';
 
-export default function Sidebar({
-  onSelectConversation,
-  onNewConversation,
-}) {
+export default function Sidebar({ onSelectConversation, onNewConversation }) {
   const { data: conversations = [] } = useConversations();
   const currentConversationId = useUIStore((s) => s.currentConversationId);
   const { data: config } = useConfig();
   const councilModels = config?.council_models || [];
   const chairmanModel = config?.chairman_model || '';
   const { data: userInfo } = useUserInfo();
-  const { sidebarOpen, setSidebarOpen } = useUIStore();
+  const { setSidebarOpen } = useUIStore();
   const currentView = useUIStore((s) => s.currentView);
   const setCurrentView = useUIStore((s) => s.setCurrentView);
+  const mode = useUIStore((s) => s.mode);
+  const setMode = useUIStore((s) => s.setMode);
 
   const deleteConversation = useDeleteConversation();
   const renameConversation = useRenameConversation();
@@ -47,12 +54,11 @@ export default function Sidebar({
     const firstElement = focusableElements[0];
     const lastElement = focusableElements[focusableElements.length - 1];
 
-    // Focus first element
     firstElement?.focus();
 
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
-        handleCancelConfig();
+        setShowConfigUI(false);
         return;
       }
       if (e.key === 'Tab') {
@@ -71,9 +77,9 @@ export default function Sidebar({
   }, [showConfigUI]);
 
   const themeIcon = {
-    system: <Monitor size={16} />,
-    light: <Sun size={16} />,
-    dark: <Moon size={16} />,
+    system: <Monitor size={14} />,
+    light: <Sun size={14} />,
+    dark: <Moon size={14} />,
   }[theme];
 
   const themeLabel = getThemeLabel(theme);
@@ -85,7 +91,10 @@ export default function Sidebar({
   };
 
   const handleSaveConfig = async () => {
-    await updateConfig.mutateAsync({ councilModels: pendingCouncil, chairmanModel: pendingChairman });
+    await updateConfig.mutateAsync({
+      councilModels: pendingCouncil,
+      chairmanModel: pendingChairman,
+    });
     setShowConfigUI(false);
   };
 
@@ -95,9 +104,7 @@ export default function Sidebar({
 
   const handleExportConversation = async (id, format) => {
     try {
-      const blob = format === 'markdown'
-        ? await api.exportMarkdown(id)
-        : await api.exportJson(id);
+      const blob = format === 'markdown' ? await api.exportMarkdown(id) : await api.exportJson(id);
 
       const conv = conversations.find((c) => c.id === id);
       const title = (conv?.title || 'conversation').replace(/[^a-zA-Z0-9]/g, '_');
@@ -119,52 +126,63 @@ export default function Sidebar({
 
   return (
     <div className="sidebar">
-      <div className="sidebar-header">
-        <div className="sidebar-title-row">
-          <h1>LLM Council</h1>
-          <button
-              className="sidebar-close-btn"
-              onClick={() => setSidebarOpen(false)}
-              aria-label="Close sidebar"
-            >
-              <X size={20} />
-            </button>
-        </div>
-        {userInfo?.authenticated && (
-          <div className="user-info">
-            <span className="user-avatar">
-              {getUserInitial(userInfo)}
-            </span>
-            <span className="user-name">
-              {getUserDisplayName(userInfo)}
-            </span>
-          </div>
-        )}
-        <button className="new-conversation-btn" onClick={onNewConversation}>
-          + New Conversation
+      {/* Brand lockup: BrandMark + two-tone wordmark */}
+      <div className="sidebar-brand">
+        <BrandMark size={30} />
+        <span className="sidebar-wordmark">
+          <span className="sidebar-wordmark-dim">LLM</span>
+          {' Council'}
+        </span>
+        <button
+          className="sidebar-close-btn"
+          onClick={() => setSidebarOpen(false)}
+          aria-label="Close sidebar"
+        >
+          <X size={18} />
         </button>
-        <nav className="sidebar-views" aria-label="Top-level views">
-          <button
-            type="button"
-            className={`sidebar-view-btn ${currentView === 'chat' ? 'active' : ''}`}
-            onClick={() => setCurrentView('chat')}
-            aria-pressed={currentView === 'chat'}
-          >
-            <MessageSquare size={14} aria-hidden="true" />
-            <span>Chat</span>
-          </button>
-          <button
-            type="button"
-            className={`sidebar-view-btn ${currentView === 'standings' ? 'active' : ''}`}
-            onClick={() => setCurrentView('standings')}
-            aria-pressed={currentView === 'standings'}
-          >
-            <Trophy size={14} aria-hidden="true" />
-            <span>Standings</span>
-          </button>
-        </nav>
       </div>
 
+      {/* CTA section */}
+      <div className="sidebar-cta-section">
+        {userInfo?.authenticated && (
+          <div className="user-info">
+            <span className="user-avatar">{getUserInitial(userInfo)}</span>
+            <span className="user-name">{getUserDisplayName(userInfo)}</span>
+          </div>
+        )}
+        {/* Solid ember CTA — single most prominent action */}
+        <button className="new-deliberation-btn" onClick={onNewConversation}>
+          <Plus size={14} aria-hidden="true" />
+          New deliberation
+        </button>
+      </div>
+
+      {/* Mode segmented control — Council / Arena */}
+      <div className="sidebar-mode-section">
+        <div className="mode-control" role="group" aria-label="Deliberation mode">
+          <button
+            type="button"
+            className={`mode-btn ${mode === 'council' ? 'active' : ''}`}
+            onClick={() => setMode('council')}
+            aria-pressed={mode === 'council'}
+          >
+            Council
+          </button>
+          <button
+            type="button"
+            className={`mode-btn ${mode === 'arena' ? 'active' : ''}`}
+            onClick={() => setMode('arena')}
+            aria-pressed={mode === 'arena'}
+          >
+            Arena
+          </button>
+        </div>
+      </div>
+
+      {/* Section label */}
+      <div className="sidebar-section-label">Today</div>
+
+      {/* Conversation list */}
       <div className="conversation-list">
         {conversations.length === 0 ? (
           <div className="no-conversations">No conversations yet</div>
@@ -183,6 +201,7 @@ export default function Sidebar({
         )}
       </div>
 
+      {/* Council display panel */}
       <CouncilDisplay
         councilModels={councilModels}
         chairmanModel={chairmanModel}
@@ -190,52 +209,60 @@ export default function Sidebar({
         onOpenCuration={() => setShowCuration(true)}
       />
 
+      {/* Footer: Standings nav · Models nav · status + theme chip */}
       <div className="sidebar-footer">
         <button
-          className="theme-toggle"
-          onClick={cycleTheme}
-          title={`Theme: ${themeLabel}`}
-          aria-label={`Theme: ${themeLabel}`}
+          type="button"
+          className={`sidebar-nav-row ${currentView === 'standings' ? 'active' : ''}`}
+          onClick={() => setCurrentView('standings')}
+          aria-pressed={currentView === 'standings'}
         >
-          {themeIcon}
+          <BarChart3 size={14} aria-hidden="true" />
+          <span>Standings</span>
         </button>
-        <VersionInfo />
+        <button
+          type="button"
+          className="sidebar-nav-row"
+          onClick={handleOpenConfig}
+          aria-label="Configure council models"
+        >
+          <Settings size={14} aria-hidden="true" />
+          <span>Models</span>
+          <span className="sidebar-model-count">{councilModels.length}</span>
+        </button>
+        <div className="sidebar-status-row">
+          <div className="sidebar-sync">
+            <span className="sidebar-sync-dot" aria-hidden="true" />
+            <span className="sidebar-sync-text">synced</span>
+            <VersionInfo />
+          </div>
+          <button
+            type="button"
+            className="sidebar-theme-chip"
+            onClick={cycleTheme}
+            title={`Theme: ${themeLabel}`}
+            aria-label={`Theme: ${themeLabel}`}
+          >
+            {themeIcon}
+            <span>{themeLabel.toLowerCase()}</span>
+          </button>
+        </div>
       </div>
 
+      {/* Config modal — ModelSelector renders its own cc-modal-* chrome
+          (backdrop, header, footer, Escape + backdrop-close). The wrapper div
+          only holds the ref so the focus trap above can reach the panel. */}
       {showConfigUI && (
-        <div
-          className="config-modal-overlay"
-          onClick={handleCancelConfig}
-          role="presentation"
-        >
-          <div
-            className="config-modal"
-            onClick={(e) => e.stopPropagation()}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="config-modal-title"
-            ref={modalRef}
-          >
-            <div className="config-modal-header">
-              <h3 id="config-modal-title">Configure Council</h3>
-              <button
-                className="modal-close-btn"
-                onClick={handleCancelConfig}
-                aria-label="Close configuration dialog"
-              >
-                <X size={20} aria-hidden="true" />
-              </button>
-            </div>
-            <ModelSelector
-              selectedCouncil={pendingCouncil}
-              selectedChairman={pendingChairman}
-              onCouncilChange={setPendingCouncil}
-              onChairmanChange={setPendingChairman}
-              onSave={handleSaveConfig}
-              onCancel={handleCancelConfig}
-              filterStateRef={filterStateRef}
-            />
-          </div>
+        <div ref={modalRef}>
+          <ModelSelector
+            selectedCouncil={pendingCouncil}
+            selectedChairman={pendingChairman}
+            onCouncilChange={setPendingCouncil}
+            onChairmanChange={setPendingChairman}
+            onSave={handleSaveConfig}
+            onCancel={handleCancelConfig}
+            filterStateRef={filterStateRef}
+          />
         </div>
       )}
 

--- a/frontend/src/components/SkeletonLoader.css
+++ b/frontend/src/components/SkeletonLoader.css
@@ -1,4 +1,4 @@
-/* Skeleton Loading Styles */
+/* Skeleton Loading Styles — uses ccPulse keyframe from index.css */
 
 .skeleton-council {
   display: flex;
@@ -8,52 +8,26 @@
 
 .skeleton-stage,
 .skeleton-synthesis {
-  background: var(--color-surface);
+  background: var(--bg-raised);
   border-radius: var(--radius-lg);
   padding: var(--space-lg);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid var(--line);
 }
 
+/* Synthesis skeleton mirrors the ember-card shape */
 .skeleton-synthesis {
-  background: linear-gradient(135deg, #f0fff0 0%, #e8f5e8 100%);
+  background: var(--bg-sunken);
+  border-color: var(--line);
 }
 
-/* Shimmer animation base - uses transform for GPU acceleration */
+/* Base style for all skeleton placeholder elements */
 .skeleton-stage-title,
 .skeleton-tab,
 .skeleton-header,
 .skeleton-line {
-  background: var(--color-sage-light);
+  background: var(--surface-hover);
   border-radius: var(--radius-sm);
-  position: relative;
-  overflow: hidden;
-}
-
-.skeleton-stage-title::after,
-.skeleton-tab::after,
-.skeleton-header::after,
-.skeleton-line::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    var(--color-cream) 50%,
-    transparent 100%
-  );
-  transform: translateX(-100%);
-  animation: shimmer 1.5s ease-in-out infinite;
-  -webkit-backface-visibility: hidden;
-}
-
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
+  animation: ccPulse 1.5s ease-in-out infinite;
 }
 
 /* Stage title skeleton */
@@ -92,10 +66,10 @@
 
 /* Content skeleton */
 .skeleton-content {
-  background: var(--color-surface-elevated);
+  background: var(--bg-raised);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid var(--line);
 }
 
 .skeleton-header {
@@ -114,23 +88,30 @@
   height: 16px;
 }
 
-/* Staggered animation delay for lines */
-.skeleton-line:nth-child(1)::after { animation-delay: 0s; }
-.skeleton-line:nth-child(2)::after { animation-delay: 0.1s; }
-.skeleton-line:nth-child(3)::after { animation-delay: 0.2s; }
-.skeleton-line:nth-child(4)::after { animation-delay: 0.3s; }
-.skeleton-line:nth-child(5)::after { animation-delay: 0.4s; }
-.skeleton-line:nth-child(6)::after { animation-delay: 0.5s; }
-.skeleton-line:nth-child(7)::after { animation-delay: 0.6s; }
-.skeleton-line:nth-child(8)::after { animation-delay: 0.7s; }
-
-/* Reduced motion preference */
-@media (prefers-reduced-motion: reduce) {
-  .skeleton-stage-title::after,
-  .skeleton-tab::after,
-  .skeleton-header::after,
-  .skeleton-line::after {
-    animation: none;
-    display: none;
-  }
+/* Stagger the pulse so lines don't all blink in sync */
+.skeleton-line:nth-child(1) {
+  animation-delay: 0s;
 }
+.skeleton-line:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.skeleton-line:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.skeleton-line:nth-child(4) {
+  animation-delay: 0.3s;
+}
+.skeleton-line:nth-child(5) {
+  animation-delay: 0.4s;
+}
+.skeleton-line:nth-child(6) {
+  animation-delay: 0.5s;
+}
+.skeleton-line:nth-child(7) {
+  animation-delay: 0.6s;
+}
+.skeleton-line:nth-child(8) {
+  animation-delay: 0.7s;
+}
+
+/* index.css already guards all animations with prefers-reduced-motion */

--- a/frontend/src/components/SkeletonLoader.jsx
+++ b/frontend/src/components/SkeletonLoader.jsx
@@ -1,5 +1,8 @@
 import './SkeletonLoader.css';
 
+// Deterministic widths so the skeleton is stable across re-renders
+const LINE_WIDTHS = [92, 78, 85, 70, 96, 74, 88, 81];
+
 export function SkeletonTabs({ count = 4 }) {
   return (
     <div className="skeleton-tabs" aria-hidden="true">
@@ -19,7 +22,7 @@ export function SkeletonContent({ lines = 5, showHeader = true }) {
           <div
             key={i}
             className="skeleton-line"
-            style={{ width: `${70 + Math.random() * 30}%` }}
+            style={{ width: `${LINE_WIDTHS[i % LINE_WIDTHS.length]}%` }}
           />
         ))}
       </div>

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -74,7 +74,7 @@
 }
 
 .standings-error {
-  border-color: var(--danger-soft);
+  border-color: var(--danger);
   color: var(--danger);
 }
 

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -1,242 +1,408 @@
 .standings {
   flex: 1;
   overflow-y: auto;
-  padding: var(--space-xl) var(--space-2xl);
-  background: var(--color-cream);
-  font-family: var(--font-body);
-  color: var(--color-text-primary);
-}
-
-.standings-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  margin-bottom: var(--space-xl);
-  padding-bottom: var(--space-lg);
-  border-bottom: 1px solid var(--color-border-light);
-}
-
-.standings-icon {
-  color: var(--color-gold-dark);
-  flex-shrink: 0;
-}
-
-.standings-header h1 {
+  background: var(--bg);
+  color: var(--fg);
   font-family: var(--font-display);
-  font-size: 1.875rem;
+}
+
+.standings-inner {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 28px 28px 80px;
+}
+
+/* ===== H1 heading ===== */
+.standings-heading {
+  margin-bottom: 24px;
+}
+
+.standings-heading h1 {
+  font-family: var(--font-head);
+  font-size: 30px;
   font-weight: 600;
-  margin: 0;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
+  color: var(--fg);
+  margin: 0 0 6px;
 }
 
 .standings-subtitle {
-  margin: var(--space-xs) 0 0;
-  color: var(--color-text-secondary);
-  font-size: 0.9375rem;
+  font-size: 14px;
+  color: var(--fg-subtle);
+  line-height: 1.5;
+  margin: 0;
 }
 
+/* ===== KPI strip ===== */
+.standings-kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 26px;
+}
+
+@media (max-width: 640px) {
+  .standings-kpi-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ===== Sections ===== */
 .standings-section {
   margin-bottom: var(--space-2xl);
 }
 
-.standings-section h2 {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
+.standings-section-heading {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
   font-weight: 600;
+  color: var(--fg-faint);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   margin: 0 0 var(--space-md);
-  color: var(--color-burgundy);
-  letter-spacing: -0.01em;
 }
 
 .standings-empty,
 .standings-error {
   padding: var(--space-lg);
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border-light);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--fg-subtle);
   font-size: 0.9375rem;
   text-align: center;
 }
 
 .standings-error {
-  border-color: var(--color-burgundy-light);
-  background: rgba(168, 61, 77, 0.06);
-  color: var(--color-burgundy);
+  border-color: var(--danger-soft);
+  color: var(--danger);
 }
 
+/* ===== Leaderboard table — card rows via border-collapse: separate ===== */
 .standings-table {
   width: 100%;
-  border-collapse: collapse;
-  background: var(--color-surface-elevated);
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  box-shadow: var(--shadow-subtle);
-  font-size: 0.9375rem;
+  border-collapse: separate;
+  border-spacing: 0 8px;
+  table-layout: auto;
 }
 
-.standings-table thead {
-  background: var(--color-parchment);
+/* Column widths — approximate the 38px 1fr 180px 64px 100px prototype grid */
+.standings-table th:nth-child(1),
+.standings-table td:nth-child(1) {
+  width: 38px;
 }
 
-.standings-table th {
-  text-align: left;
-  padding: 0;
-  font-family: var(--font-display);
+.standings-table th:nth-child(3),
+.standings-table td:nth-child(3) {
+  width: 180px;
+}
+
+.standings-table th:nth-child(4),
+.standings-table td:nth-child(4) {
+  width: 64px;
+}
+
+.standings-table th:nth-child(5),
+.standings-table td:nth-child(5) {
+  width: 110px;
+}
+
+/* Header row */
+.standings-table thead th {
+  padding: 0 8px 10px;
+  font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.875rem;
-  color: var(--color-text-secondary);
-  letter-spacing: 0.04em;
+  font-size: 10px;
+  color: var(--fg-faint);
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  border: none;
+  background: transparent;
+}
+
+.standings-table thead th:first-child {
+  padding-left: 16px;
+}
+
+.standings-table thead th:last-child {
+  padding-right: 16px;
+}
+
+.standings-table thead th.num {
+  text-align: right;
 }
 
 .sort-header-btn {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  width: 100%;
-  padding: var(--space-md) var(--space-lg);
+  gap: 4px;
   background: transparent;
   border: none;
+  padding: 0;
   font: inherit;
   color: inherit;
   text-transform: inherit;
   letter-spacing: inherit;
   cursor: pointer;
   text-align: left;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition: color var(--dur-micro) var(--ease-out);
 }
 
-.standings-table th.num .sort-header-btn {
+.standings-table thead th.num .sort-header-btn {
   justify-content: flex-end;
-  text-align: right;
+  width: 100%;
 }
 
 .sort-header-btn:hover {
-  background: var(--color-ivory);
-  color: var(--color-burgundy);
+  color: var(--fg);
 }
 
 .sort-header-btn:focus-visible {
-  outline: 2px solid var(--color-burgundy);
-  outline-offset: -2px;
-}
-
-.sort-icon {
-  flex-shrink: 0;
-  color: var(--color-burgundy);
-}
-
-.sort-icon.inactive {
-  color: var(--color-text-muted);
-  opacity: 0.5;
-}
-
-.standings-table td {
-  padding: var(--space-md) var(--space-lg);
-  border-bottom: 1px solid var(--color-border-light);
-}
-
-.standings-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.standings-table tbody tr {
-  transition: background var(--transition-fast);
-}
-
-.standings-table tbody tr:hover {
-  background: var(--color-ivory);
-}
-
-.standings-table tbody tr.selected {
-  background: var(--color-stage2);
-}
-
-.model-select-btn {
-  background: transparent;
-  border: none;
-  padding: 0;
-  font: inherit;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  text-align: left;
-  text-decoration: none;
-  transition: color var(--transition-fast);
-}
-
-.model-select-btn:hover {
-  color: var(--color-burgundy);
-  text-decoration: underline;
-}
-
-.model-select-btn:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
 }
 
-.model-select-btn[aria-pressed="true"] {
-  color: var(--color-burgundy);
-  font-weight: 600;
+.sort-icon {
+  flex-shrink: 0;
+  color: var(--accent);
 }
 
-.standings-table .rank {
-  font-family: var(--font-display);
-  font-weight: 600;
-  color: var(--color-burgundy);
-  width: 60px;
+.sort-icon.inactive {
+  color: var(--fg-faint);
+  opacity: 0.5;
 }
 
-.standings-table .model {
+/* Data rows — card style via per-cell borders + separate collapse */
+.standings-table tbody td {
+  padding: 14px 8px;
+  background: var(--bg-raised);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+
+.standings-table tbody td:first-child {
+  border-left: 1px solid var(--line);
+  border-radius: 11px 0 0 11px;
+  padding-left: 16px;
+}
+
+.standings-table tbody td:last-child {
+  border-right: 1px solid var(--line);
+  border-radius: 0 11px 11px 0;
+  padding-right: 16px;
+}
+
+/* #1 row: accent border on all sides */
+.standings-table tbody tr.row-top td {
+  border-top-color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.standings-table tbody tr.row-top td:first-child {
+  border-left-color: var(--accent);
+}
+
+.standings-table tbody tr.row-top td:last-child {
+  border-right-color: var(--accent);
+}
+
+.standings-table tbody tr.selected td {
+  background: var(--accent-soft);
+}
+
+.standings-table tbody tr:hover td {
+  border-color: var(--line-strong);
+}
+
+.standings-table tbody tr.row-top:hover td {
+  border-color: var(--accent-hover);
+}
+
+/* Rank cell */
+.rank-num {
   font-family: var(--font-mono);
-  font-size: 0.8125rem;
-  color: var(--color-text-primary);
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--fg-faint);
 }
 
-.standings-table .num {
+/* Model cell */
+.standings-table td.model {
+  padding-left: 8px;
+}
+
+.model-select-btn {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  min-width: 0;
+  transition: opacity var(--dur-micro) var(--ease-out);
+}
+
+.model-select-btn:hover {
+  opacity: 0.8;
+}
+
+.model-select-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.model-select-btn[aria-pressed='true'] .model-name {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.model-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+  min-width: 0;
+}
+
+.model-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.model-name {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* "CHAIR" mono micro-tag */
+.model-chair-tag {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.03em;
+  flex: none;
+}
+
+.model-sub {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Rating cell: bar + value */
+.standings-table td.rating-cell {
+  padding: 14px 8px;
+}
+
+.rating-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+/* Sunken track */
+.rating-bar-track {
+  flex: 1;
+  height: 8px;
+  background: var(--bg-sunken);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+/* Fill: width from inline style; grows via ccBar animation */
+.rating-bar-fill {
+  height: 100%;
+  border-radius: 5px;
+  transform-origin: left;
+  animation: ccBar var(--dur-deliberate) var(--ease-out) both;
+}
+
+.rating-val {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--fg);
+  width: 34px;
   text-align: right;
+  flex: none;
+}
+
+/* Numeric cells */
+.standings-table td.num,
+.standings-table td.games-cell {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
+  text-align: right;
+  font-size: 13px;
+  color: var(--fg-muted);
 }
 
-.standings-table .ts {
-  color: var(--color-text-muted);
-  font-size: 0.8125rem;
+/* Timestamp */
+.standings-table td.ts {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
   white-space: nowrap;
+  text-align: right;
+}
+
+/* Footnote */
+.standings-footnote {
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+  margin-top: 18px;
+  text-align: center;
 }
 
 .standings-filter-hint {
   margin: var(--space-sm) 0 0;
   font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+  color: var(--fg-subtle);
   text-align: right;
+  font-family: var(--font-display);
 }
 
+/* ===== Trend chart ===== */
 .standings-chart {
-  background: var(--color-surface-elevated);
-  border: 1px solid var(--color-border-light);
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
   padding: var(--space-lg) var(--space-md) var(--space-md);
-  box-shadow: var(--shadow-subtle);
 }
 
+/* ===== Responsive ===== */
 @media (max-width: 768px) {
-  .standings {
-    padding: var(--space-lg) var(--space-md);
+  .standings-inner {
+    padding: 20px 16px 60px;
   }
-  .standings-table th,
-  .standings-table td {
-    padding: var(--space-sm);
-    font-size: 0.8125rem;
+
+  .standings-heading h1 {
+    font-size: 24px;
   }
-  /* Hide both header and body for the "Last seen" column on small screens
-     to keep the columns aligned — hiding only .ts (body cells) leaves the
-     header behind and shifts the whole row by one column. */
+
+  /* Hide last-seen column on small screens — both header and cells to keep columns aligned */
   .standings-table th:nth-child(5),
-  .standings-table .ts {
+  .standings-table td:nth-child(5) {
     display: none;
   }
 }

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -9,31 +9,27 @@ import {
   Legend,
   CartesianGrid,
 } from 'recharts';
-import { Trophy, ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
-import { useRankings, useRankingsHistory } from '../hooks/queries';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { useRankings, useRankingsHistory, useConversations, useConfig } from '../hooks/queries';
+import { useSeatColors } from '../hooks/useSeatColors';
+import { KpiCard, SeatAvatar } from './ui';
 import './Standings.css';
 
-// Stage palette for line colors — falls back to burgundy/gold/sage tones for >3 series.
-const SERIES_COLORS = [
-  'var(--color-stage1-accent)',
-  'var(--color-stage2-accent)',
-  'var(--color-stage3-accent)',
-  'var(--color-burgundy)',
-  'var(--color-gold-dark)',
-  'var(--color-burgundy-light)',
-];
-
 const SORTABLE_COLUMNS = [
-  { key: 'rank', label: 'Rank', numeric: true },
-  { key: 'model', label: 'Model', numeric: false },
-  { key: 'rating', label: 'Rating', numeric: true },
-  { key: 'games', label: 'Games', numeric: true },
-  { key: 'last_updated', label: 'Last seen', numeric: false },
+  { key: 'rank', label: '#', numeric: true },
+  { key: 'model', label: 'model', numeric: false },
+  { key: 'rating', label: 'rating', numeric: true },
+  { key: 'games', label: 'games', numeric: true },
+  { key: 'last_updated', label: 'last seen', numeric: false },
 ];
 
 function formatModel(id) {
   // OpenRouter ids look like "anthropic/claude-sonnet-4.5" — show the right half.
   return id?.split('/').slice(-1)[0] || id;
+}
+
+function formatProvider(id) {
+  return id?.split('/')[0] || '';
 }
 
 function formatTimestamp(iso) {
@@ -50,11 +46,23 @@ function formatTimestamp(iso) {
   }
 }
 
+/** Short date for KPI display: relative within 24h, then "Mon DD". */
+function formatShortDate(iso) {
+  if (!iso) return '—';
+  try {
+    const diff = Date.now() - new Date(iso).getTime();
+    const hrs = diff / 3600000;
+    if (hrs < 1) return `${Math.floor(diff / 60000)}m ago`;
+    if (hrs < 24) return `${Math.floor(hrs)}h ago`;
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return '—';
+  }
+}
+
 /**
  * Group history snapshots by timestamp so each x-step represents one real
- * match event, not one per-model snapshot. Without this grouping a single
- * pairwise match (which updates two models simultaneously) would create
- * two x-steps and distort the trend.
+ * match event, not one per-model snapshot.
  */
 function buildChartSeries(history) {
   const eventsByTs = new Map();
@@ -73,7 +81,13 @@ function buildChartSeries(history) {
 }
 
 export default function Standings() {
-  const { data: rankingsData, isLoading: leaderboardLoading, error: leaderboardError } = useRankings();
+  const {
+    data: rankingsData,
+    isLoading: leaderboardLoading,
+    error: leaderboardError,
+  } = useRankings();
+  const { data: config } = useConfig();
+  const { data: conversations = [] } = useConversations();
   const [selectedModel, setSelectedModel] = useState(null);
   const [sortConfig, setSortConfig] = useState({ key: 'rating', dir: 'desc' });
   const {
@@ -82,10 +96,34 @@ export default function Standings() {
     error: historyError,
   } = useRankingsHistory(selectedModel);
 
-  const leaderboard = rankingsData?.leaderboard || [];
-  const history = historyData?.history || {};
+  const { seatOf } = useSeatColors();
+  const chairmanModel = config?.chairman_model || '';
+
+  const leaderboard = useMemo(() => rankingsData?.leaderboard || [], [rankingsData]);
+  const history = useMemo(() => historyData?.history || {}, [historyData]);
   const chartData = useMemo(() => buildChartSeries(history), [history]);
   const modelKeys = Object.keys(history);
+
+  // Highest rating in the board — used to normalize bar widths.
+  const maxRating = useMemo(
+    () => (leaderboard.length ? Math.max(...leaderboard.map((r) => r.rating || 0)) : 1),
+    [leaderboard]
+  );
+
+  // KPI derived values
+  const totalGames = useMemo(
+    () => leaderboard.reduce((s, r) => s + (r.games || 0), 0),
+    [leaderboard]
+  );
+
+  const mostRecentTs = useMemo(() => {
+    const ts = leaderboard
+      .map((r) => r.last_updated)
+      .filter(Boolean)
+      .sort()
+      .pop();
+    return formatShortDate(ts);
+  }, [leaderboard]);
 
   const sortedLeaderboard = useMemo(() => {
     const { key, dir } = sortConfig;
@@ -104,7 +142,6 @@ export default function Standings() {
   const handleSort = (key) => {
     setSortConfig((prev) => {
       if (prev.key !== key) {
-        // First click on a new column: numeric defaults to desc, text to asc.
         const col = SORTABLE_COLUMNS.find((c) => c.key === key);
         return { key, dir: col?.numeric ? 'desc' : 'asc' };
       }
@@ -118,157 +155,237 @@ export default function Standings() {
 
   const sortIcon = (key) => {
     if (sortConfig.key !== key) {
-      return <ArrowUpDown size={12} aria-hidden="true" className="sort-icon inactive" />;
+      return <ArrowUpDown size={11} aria-hidden="true" className="sort-icon inactive" />;
     }
-    return sortConfig.dir === 'asc'
-      ? <ArrowUp size={12} aria-hidden="true" className="sort-icon" />
-      : <ArrowDown size={12} aria-hidden="true" className="sort-icon" />;
+    return sortConfig.dir === 'asc' ? (
+      <ArrowUp size={11} aria-hidden="true" className="sort-icon" />
+    ) : (
+      <ArrowDown size={11} aria-hidden="true" className="sort-icon" />
+    );
   };
 
   return (
     <main className="standings">
-      <header className="standings-header">
-        <Trophy size={28} className="standings-icon" aria-hidden="true" />
-        <div>
-          <h1>Council Standings</h1>
+      <div className="standings-inner">
+        {/* H1 in --font-head */}
+        <div className="standings-heading">
+          <h1>Council standings</h1>
           <p className="standings-subtitle">
             ELO ratings derived from Stage 2 peer rankings, replayed across every council round.
           </p>
         </div>
-      </header>
 
-      <section className="standings-section">
-        <h2>Leaderboard</h2>
-        {leaderboardLoading ? (
-          <div className="standings-empty">Loading…</div>
-        ) : leaderboardError ? (
-          <div className="standings-error" role="alert">
-            Failed to load leaderboard: {leaderboardError.message || 'Unknown error'}
-          </div>
-        ) : leaderboard.length === 0 ? (
-          <div className="standings-empty">
-            No matches recorded yet. Run a council round to start tracking ratings.
-          </div>
-        ) : (
-          <table className="standings-table">
-            <thead>
-              <tr>
-                {SORTABLE_COLUMNS.map((col) => {
-                  const isActive = sortConfig.key === col.key;
-                  return (
-                    <th
-                      key={col.key}
-                      scope="col"
-                      className={col.numeric ? 'num' : ''}
-                      aria-sort={
-                        isActive
-                          ? sortConfig.dir === 'asc' ? 'ascending' : 'descending'
-                          : 'none'
-                      }
-                    >
-                      <button
-                        type="button"
-                        className="sort-header-btn"
-                        onClick={() => handleSort(col.key)}
-                      >
-                        <span>{col.label}</span>
-                        {sortIcon(col.key)}
-                      </button>
-                    </th>
-                  );
-                })}
-              </tr>
-            </thead>
-            <tbody>
-              {sortedLeaderboard.map((row) => {
-                const isSelected = selectedModel === row.model;
-                return (
-                  <tr key={row.model} className={isSelected ? 'selected' : ''}>
-                    <td className="rank">{row.rank}</td>
-                    <td className="model" title={row.model}>
-                      <button
-                        type="button"
-                        className="model-select-btn"
-                        aria-pressed={isSelected}
-                        aria-label={
-                          isSelected
-                            ? `Clear filter on ${formatModel(row.model)}`
-                            : `Filter trend chart to ${formatModel(row.model)}`
-                        }
-                        onClick={() => toggleSelection(row.model)}
-                      >
-                        {formatModel(row.model)}
-                      </button>
-                    </td>
-                    <td className="num">{Math.round(row.rating)}</td>
-                    <td className="num">{row.games}</td>
-                    <td className="ts">{formatTimestamp(row.last_updated)}</td>
+        {/* KPI strip — frontend-only, real data only */}
+        <div className="standings-kpi-strip">
+          <KpiCard label="DELIBERATIONS" value={conversations.length} sub="all time" />
+          <KpiCard label="MODELS TRACKED" value={leaderboard.length} sub="in leaderboard" />
+          <KpiCard label="TOTAL MATCHES" value={totalGames} sub="peer ballots cast" />
+          <KpiCard label="MOST RECENT" value={mostRecentTs} sub="last deliberation" />
+        </div>
+
+        {/* Leaderboard */}
+        <section className="standings-section">
+          {leaderboardLoading ? (
+            <div className="standings-empty">Loading…</div>
+          ) : leaderboardError ? (
+            <div className="standings-error" role="alert">
+              Failed to load leaderboard: {leaderboardError.message || 'Unknown error'}
+            </div>
+          ) : leaderboard.length === 0 ? (
+            <div className="standings-empty">
+              No matches recorded yet. Run a council round to start tracking ratings.
+            </div>
+          ) : (
+            <>
+              <table className="standings-table" aria-label="Council standings leaderboard">
+                <thead>
+                  <tr>
+                    {SORTABLE_COLUMNS.map((col) => {
+                      const isActive = sortConfig.key === col.key;
+                      return (
+                        <th
+                          key={col.key}
+                          scope="col"
+                          className={col.numeric ? 'num' : ''}
+                          aria-sort={
+                            isActive
+                              ? sortConfig.dir === 'asc'
+                                ? 'ascending'
+                                : 'descending'
+                              : 'none'
+                          }
+                        >
+                          <button
+                            type="button"
+                            className="sort-header-btn"
+                            onClick={() => handleSort(col.key)}
+                          >
+                            <span>{col.label}</span>
+                            {sortIcon(col.key)}
+                          </button>
+                        </th>
+                      );
+                    })}
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-        {selectedModel && (
-          <p className="standings-filter-hint">
-            Filtered to <strong>{formatModel(selectedModel)}</strong> — click the model name again to clear.
-          </p>
-        )}
-      </section>
+                </thead>
+                <tbody>
+                  {sortedLeaderboard.map((row) => {
+                    const isSelected = selectedModel === row.model;
+                    const isTop = row.rank === 1;
+                    const seat = seatOf(row.model);
+                    const barWidth = Math.round(((row.rating || 0) / maxRating) * 100);
+                    const isChair = row.model === chairmanModel;
 
-      <section className="standings-section">
-        <h2>Trend</h2>
-        {historyLoading ? (
-          <div className="standings-empty">Loading…</div>
-        ) : historyError ? (
-          <div className="standings-error" role="alert">
-            Failed to load trend history: {historyError.message || 'Unknown error'}
-          </div>
-        ) : modelKeys.length === 0 ? (
-          <div className="standings-empty">No history yet.</div>
-        ) : (
-          <div className="standings-chart">
-            <ResponsiveContainer width="100%" height={360}>
-              <LineChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
-                <CartesianGrid stroke="var(--color-border-light)" strokeDasharray="3 3" />
-                <XAxis
-                  dataKey="idx"
-                  stroke="var(--color-text-muted)"
-                  label={{ value: 'Match #', position: 'insideBottom', offset: -2, fill: 'var(--color-text-muted)' }}
-                />
-                <YAxis
-                  stroke="var(--color-text-muted)"
-                  domain={['dataMin - 20', 'dataMax + 20']}
-                />
-                <Tooltip
-                  contentStyle={{
-                    background: 'var(--color-surface-elevated)',
-                    border: '1px solid var(--color-border)',
-                    borderRadius: 'var(--radius-sm)',
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: '0.8125rem',
-                  }}
-                  labelFormatter={(idx) => `Match ${idx}`}
-                  formatter={(value, name) => [Math.round(value), formatModel(name)]}
-                />
-                <Legend formatter={(value) => formatModel(value)} />
-                {modelKeys.map((model, i) => (
-                  <Line
-                    key={model}
-                    type="monotone"
-                    dataKey={model}
-                    stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
-                    strokeWidth={2}
-                    dot={false}
-                    connectNulls
-                    isAnimationActive={false}
+                    return (
+                      <tr
+                        key={row.model}
+                        className={[isTop ? 'row-top' : '', isSelected ? 'selected' : '']
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        {/* Rank */}
+                        <td className="rank">
+                          <span className="rank-num">{row.rank}</span>
+                        </td>
+
+                        {/* Model: avatar + name + CHAIR tag + provider */}
+                        <td className="model" title={row.model}>
+                          <button
+                            type="button"
+                            className="model-select-btn"
+                            aria-pressed={isSelected}
+                            aria-label={
+                              isSelected
+                                ? `Clear filter on ${formatModel(row.model)}`
+                                : `Filter trend chart to ${formatModel(row.model)}`
+                            }
+                            onClick={() => toggleSelection(row.model)}
+                          >
+                            <SeatAvatar
+                              color={seat.color}
+                              name={formatModel(row.model)}
+                              size={28}
+                            />
+                            <div className="model-info">
+                              <div className="model-name-row">
+                                <span className="model-name">{formatModel(row.model)}</span>
+                                {isChair && <span className="model-chair-tag">CHAIR</span>}
+                              </div>
+                              <span className="model-sub">
+                                {formatProvider(row.model)} · {row.games} councils
+                              </span>
+                            </div>
+                          </button>
+                        </td>
+
+                        {/* Rating: seat-colored bar + numeric value */}
+                        <td className="rating-cell">
+                          <div className="rating-bar-wrap">
+                            <div className="rating-bar-track">
+                              <div
+                                className="rating-bar-fill"
+                                style={{
+                                  width: `${barWidth}%`,
+                                  background: seat.color,
+                                }}
+                              />
+                            </div>
+                            <span className="rating-val">{Math.round(row.rating)}</span>
+                          </div>
+                        </td>
+
+                        {/* Games */}
+                        <td className="num games-cell">{row.games}</td>
+
+                        {/* Last seen */}
+                        <td className="ts">{formatTimestamp(row.last_updated)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <p className="standings-footnote">
+                rating = ELO score derived from blind peer rankings across deliberations
+              </p>
+            </>
+          )}
+          {selectedModel && (
+            <p className="standings-filter-hint">
+              Filtered to <strong>{formatModel(selectedModel)}</strong> — click the model name again
+              to clear.
+            </p>
+          )}
+        </section>
+
+        {/* Trend chart */}
+        <section className="standings-section">
+          <h2 className="standings-section-heading">Trend</h2>
+          {historyLoading ? (
+            <div className="standings-empty">Loading…</div>
+          ) : historyError ? (
+            <div className="standings-error" role="alert">
+              Failed to load trend history: {historyError.message || 'Unknown error'}
+            </div>
+          ) : modelKeys.length === 0 ? (
+            <div className="standings-empty">No history yet.</div>
+          ) : (
+            <div className="standings-chart">
+              <ResponsiveContainer width="100%" height={360}>
+                <LineChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+                  <CartesianGrid stroke="var(--line)" strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="idx"
+                    stroke="var(--fg-faint)"
+                    tick={{ fontFamily: 'var(--font-mono)', fontSize: 11, fill: 'var(--fg-faint)' }}
+                    label={{
+                      value: 'Match #',
+                      position: 'insideBottom',
+                      offset: -2,
+                      fill: 'var(--fg-faint)',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 11,
+                    }}
                   />
-                ))}
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        )}
-      </section>
+                  <YAxis
+                    stroke="var(--fg-faint)"
+                    tick={{ fontFamily: 'var(--font-mono)', fontSize: 11, fill: 'var(--fg-faint)' }}
+                    domain={['dataMin - 20', 'dataMax + 20']}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: 'var(--bg-raised)',
+                      border: '1px solid var(--line)',
+                      borderRadius: '8px',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: '0.75rem',
+                      color: 'var(--fg)',
+                    }}
+                    labelStyle={{ color: 'var(--fg-faint)' }}
+                    labelFormatter={(idx) => `Match ${idx}`}
+                    formatter={(value, name) => [Math.round(value), formatModel(name)]}
+                  />
+                  <Legend
+                    formatter={(value) => formatModel(value)}
+                    wrapperStyle={{ fontFamily: 'var(--font-mono)', fontSize: '0.75rem' }}
+                  />
+                  {modelKeys.map((model) => (
+                    <Line
+                      key={model}
+                      type="monotone"
+                      dataKey={model}
+                      stroke={seatOf(model).color}
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </section>
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/Synthesis.css
+++ b/frontend/src/components/Synthesis.css
@@ -1,130 +1,90 @@
-/* Unified Synthesis Component Styles */
+/* Unified Synthesis Component Styles — the visual climax of a deliberation */
 
 .synthesis {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  position: relative;
+  background: var(--bg-raised);
+  border: 1px solid var(--accent);
   border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-md);
   overflow: hidden;
 }
 
-/* Mode-specific accents */
-.synthesis-council {
-  --synthesis-accent: var(--color-stage3-accent, #2e7d32);
-}
-
-.synthesis-arena {
-  --synthesis-accent: var(--arena-accent, #2e7d32);
-}
-
-/* Header */
-.synthesis-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-md) var(--space-lg);
-  background: var(--color-surface-elevated);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.synthesis-title {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.synthesis-title::before {
+/* 3px ember bar down the left edge */
+.synthesis::before {
   content: '';
-  width: 16px;
-  height: 16px;
-  background: var(--color-gold);
-  border-radius: 50%;
-  flex-shrink: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background: var(--accent);
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  pointer-events: none;
 }
 
-.synthesis-header-actions {
+/* ── Chairman header ──────────────────────────────────────────────────────── */
+.synthesis-chairman-header {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.synthesis-chairman-icon {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.synthesis-chairman-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.synthesis-chairman-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.synthesis-chairman-sub {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-faint);
+}
+
+.synthesis-reasoning-indicator {
+  color: var(--warning);
+  margin-left: auto;
 }
 
 .synthesis-cost {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: 3px;
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 11px;
   font-weight: 500;
-  color: var(--color-gold-dark);
-  background: var(--color-gold-light);
-  padding: 2px 6px;
+  color: var(--fg-subtle);
+  background: var(--surface);
+  padding: 2px 7px;
   border-radius: var(--radius-sm);
-}
-
-.synthesis-cost svg {
-  opacity: 0.7;
-}
-
-.synthesis .copy-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-xs);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  transition: border-color var(--transition-fast), color var(--transition-fast);
-}
-
-.synthesis .copy-btn:hover {
-  border-color: var(--synthesis-accent);
-  color: var(--synthesis-accent);
-}
-
-/* Content area */
-.synthesis-content {
-  padding: var(--space-lg);
-}
-
-.chairman-info {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-md);
-  padding-bottom: var(--space-sm);
-  border-bottom: 1px dashed var(--color-border);
-}
-
-.chairman-label {
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.chairman-model {
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-}
-
-.synthesis .reasoning-indicator {
-  color: var(--color-gold);
+  border: 1px solid var(--line);
   margin-left: auto;
 }
 
-/* Reasoning section */
+/* ── Reasoning section ────────────────────────────────────────────────────── */
 .synthesis .reasoning-section {
-  margin-bottom: var(--space-md);
-  border: 1px solid var(--color-border);
+  margin-bottom: 14px;
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
   overflow: hidden;
 }
@@ -132,23 +92,22 @@
 .synthesis .reasoning-toggle {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  gap: 8px;
   width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-parchment);
+  padding: 8px 12px;
+  background: var(--bg-sunken);
   border: none;
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 500;
-  color: var(--color-text-secondary);
+  color: var(--fg-subtle);
   text-align: left;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition: background var(--dur-micro) var(--ease-out);
 }
 
 .synthesis .reasoning-toggle:hover {
-  background: var(--color-ivory);
-  color: var(--color-text-primary);
+  background: var(--surface-hover);
 }
 
 .synthesis .reasoning-toggle svg {
@@ -157,165 +116,177 @@
 }
 
 .synthesis .reasoning-content {
-  padding: var(--space-md);
-  background: var(--color-surface);
-  border-top: 1px solid var(--color-border);
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+  padding: 12px;
+  background: var(--bg-sunken);
+  border-top: 1px solid var(--line);
+  font-size: 13px;
+  color: var(--fg-subtle);
   line-height: 1.65;
   max-height: 300px;
   overflow-y: auto;
 }
 
 .synthesis .reasoning-content p {
-  margin: 0 0 var(--space-sm) 0;
+  margin: 0 0 8px 0;
 }
 
 .synthesis .reasoning-content p:last-child {
   margin-bottom: 0;
 }
 
-/* Synthesis text */
+/* ── Final answer ────────────────────────────────────────────────────────── */
 .synthesis-text {
-  font-family: var(--font-body);
-  line-height: 1.75;
-  color: var(--color-text-primary);
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--fg);
 }
 
-/* Identity reveal for Arena */
+/* Error state — shown when chairman call failed */
+.synthesis-error {
+  color: var(--danger);
+  background: var(--danger-soft);
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--danger);
+}
+
+/* ── Arena identity reveal ────────────────────────────────────────────────── */
 .identity-reveal {
-  background: var(--color-surface-elevated);
-  border-top: 1px solid var(--color-border);
-  padding: var(--space-md) var(--space-lg);
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
 }
 
 .reveal-title {
-  margin: 0 0 var(--space-sm) 0;
+  margin: 0 0 8px;
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 10.5px;
   font-weight: 600;
-  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  color: var(--fg-faint);
 }
 
 .participant-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: 4px;
 }
 
 .participant-identity {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  gap: 8px;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
-  padding: var(--space-xs) 0;
+  font-size: 12px;
+  padding: 2px 0;
 }
 
 .identity-label {
   font-weight: 600;
-  color: var(--color-gold-dark);
+  color: var(--fg-subtle);
   min-width: 100px;
 }
 
 .identity-arrow {
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
 }
 
 .identity-model {
   font-weight: 500;
-  color: var(--color-text-primary);
+  color: var(--fg);
 }
 
 .identity-full-model {
-  font-size: 0.6875rem;
-  color: var(--color-text-muted);
-  font-style: italic;
+  font-size: 11px;
+  color: var(--fg-faint);
 }
 
-/* Action buttons section */
+/* ── Action row ──────────────────────────────────────────────────────────── */
 .synthesis-actions {
-  padding: var(--space-md) var(--space-lg);
-  border-top: 1px dashed var(--color-border);
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-sm);
-}
-
-/* One more round button */
-.extend-debate-btn {
   display: flex;
   align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-gold-light);
-  border: 1px solid var(--color-gold);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-gold-dark);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
 }
 
-.extend-debate-btn:hover:not(:disabled) {
-  background: var(--color-gold);
-  color: white;
-}
-
-.extend-debate-btn:active:not(:disabled) {
-  transform: scale(0.98);
-}
-
-.extend-debate-btn:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
-/* Synthesis error state */
-.synthesis-error {
-  color: var(--color-error, #d32f2f);
-  background: var(--color-error-light, #fff3f3);
-  padding: var(--space-md);
+/* Solid ember: "Copy answer" */
+.synthesis-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  background: var(--accent);
+  color: var(--fg-on-accent);
+  border: none;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-error-border, #ffcdd2);
-}
-
-/* Retry synthesis button */
-.retry-synthesis-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-error-light, #fff3f3);
-  border: 1px solid var(--color-error-border, #ffcdd2);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-error, #d32f2f);
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 600;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
 }
 
-.retry-synthesis-btn:hover:not(:disabled) {
-  background: var(--color-error, #d32f2f);
-  color: white;
+.synthesis-copy-btn:hover {
+  background: var(--accent-hover);
 }
 
-.retry-synthesis-btn:active:not(:disabled) {
+.synthesis-copy-btn:active {
   transform: scale(0.98);
 }
 
-.retry-synthesis-btn:disabled {
-  opacity: 0.7;
+.synthesis-copy-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
+/* Ghost buttons: "Fork & refine", "Re-synthesize", "One More Round" */
+.synthesis-ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  background: var(--surface);
+  color: var(--fg-muted);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
+}
+
+.synthesis-ghost-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg);
+}
+
+.synthesis-ghost-btn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.synthesis-ghost-btn:disabled {
+  opacity: 0.6;
   cursor: not-allowed;
 }
 
-/* Spinner used inside action buttons */
+.synthesis-ghost-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+
+/* Spinner used inside loading buttons */
 .spinner-small {
   width: 14px;
   height: 14px;
@@ -324,6 +295,7 @@
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
   opacity: 0.7;
+  flex: none;
 }
 
 @keyframes spin {
@@ -332,50 +304,16 @@
   }
 }
 
-/* Continue Discussion - legacy */
-.continue-discussion {
-  padding: var(--space-md) var(--space-lg);
-  border-top: 1px dashed var(--color-border);
-  display: flex;
-  justify-content: flex-end;
-}
-
-.continue-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
-}
-
-.continue-btn:hover {
-  background: var(--color-ivory);
-  border-color: var(--synthesis-accent);
-  color: var(--synthesis-accent);
-}
-
-.continue-btn:active {
-  transform: scale(0.98);
-}
-
-/* Markdown content styling */
+/* ── Markdown overrides scoped to synthesis ─────────────────────────────── */
 .synthesis .markdown-content h2 {
   font-family: var(--font-display);
-  font-size: 0.9375rem;
+  font-size: 15px;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--fg);
   margin-top: 1.5em;
   margin-bottom: 0.5em;
   padding-bottom: 0.25em;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--line);
 }
 
 .synthesis .markdown-content h2:first-child {

--- a/frontend/src/components/Synthesis.jsx
+++ b/frontend/src/components/Synthesis.jsx
@@ -1,7 +1,18 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronDown, ChevronRight, Brain, MessageSquarePlus, Copy, Check, DollarSign, Plus, RefreshCw } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Brain,
+  Copy,
+  Check,
+  Crown,
+  GitFork,
+  RotateCw,
+  Plus,
+  Coins,
+} from 'lucide-react';
 import { formatCost, getReasoningText } from '../lib/formatting';
 import './Synthesis.css';
 
@@ -51,49 +62,54 @@ export default function Synthesis({
 
   return (
     <div className={`synthesis synthesis-${mode}`}>
-      <div className="synthesis-header">
-        <h3 className="synthesis-title">{isArena ? 'Final Synthesis' : 'Final Council Answer'}</h3>
-        <div className="synthesis-header-actions">
-          {synthesisCost > 0 && (
-            <span className="synthesis-cost" title="Synthesis cost">
-              <DollarSign size={12} />
-              {formatCost(synthesisCost)}
-            </span>
-          )}
-          <button className="copy-btn" onClick={handleCopy} title="Copy synthesis">
-            {copied ? <Check size={14} /> : <Copy size={14} />}
-          </button>
+      {/* Chairman header — ember icon + title + subline */}
+      <div className="synthesis-chairman-header">
+        <span className="synthesis-chairman-icon">
+          <Crown size={14} strokeWidth={2} />
+        </span>
+        <div className="synthesis-chairman-info">
+          <span className="synthesis-chairman-title">
+            {isArena ? "Chairman's ruling" : "Chairman's synthesis"}
+          </span>
+          <span className="synthesis-chairman-sub">
+            {isArena ? `de-anonymized · ${modelName}` : 'weighted by peer standings'}
+          </span>
         </div>
+        {hasReasoning && (
+          <Brain size={14} className="synthesis-reasoning-indicator" aria-hidden="true" />
+        )}
+        {synthesisCost > 0 && (
+          <span className="synthesis-cost" title="Synthesis cost">
+            <Coins size={11} strokeWidth={2} />
+            {formatCost(synthesisCost)}
+          </span>
+        )}
       </div>
 
-      <div className="synthesis-content">
-        <div className="chairman-info">
-          <span className="chairman-label">{isArena ? 'Synthesized by:' : 'Chairman:'}</span>
-          <span className="chairman-model">{modelName}</span>
-          {hasReasoning && <Brain size={14} className="reasoning-indicator" />}
+      {/* Chairman reasoning */}
+      {hasReasoning && (
+        <div className="reasoning-section">
+          <button
+            className="reasoning-toggle"
+            onClick={() => setReasoningExpanded(!reasoningExpanded)}
+          >
+            {reasoningExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+            <Brain size={14} />
+            <span>Chairman's Reasoning Process</span>
+          </button>
+          {reasoningExpanded && (
+            <div className="reasoning-content">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoningText}</ReactMarkdown>
+            </div>
+          )}
         </div>
+      )}
 
-        {hasReasoning && (
-          <div className="reasoning-section">
-            <button
-              className="reasoning-toggle"
-              onClick={() => setReasoningExpanded(!reasoningExpanded)}
-            >
-              {reasoningExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-              <Brain size={14} />
-              <span>Chairman's Reasoning Process</span>
-            </button>
-            {reasoningExpanded && (
-              <div className="reasoning-content">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoningText}</ReactMarkdown>
-              </div>
-            )}
-          </div>
-        )}
-
-        <div className={`synthesis-text markdown-content${isSynthesisError ? ' synthesis-error' : ''}`}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-        </div>
+      {/* Final answer prose */}
+      <div
+        className={`synthesis-text markdown-content${isSynthesisError ? ' synthesis-error' : ''}`}
+      >
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
       </div>
 
       {/* Participant identity reveal for Arena mode */}
@@ -113,61 +129,49 @@ export default function Synthesis({
         </div>
       )}
 
-      {/* Action buttons */}
+      {/* Action row */}
       <div className="synthesis-actions">
-        {/* Retry synthesis button when chairman failed */}
+        {/* Primary: solid ember copy button */}
+        <button className="synthesis-copy-btn" onClick={handleCopy} title="Copy synthesis">
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+          Copy answer
+        </button>
+
+        {/* Fork & refine */}
+        {onForkConversation && originalQuestion && (
+          <button
+            className="synthesis-ghost-btn"
+            onClick={handleContinueDiscussion}
+            title="Start a new conversation with this context"
+          >
+            <GitFork size={14} />
+            Fork &amp; refine
+          </button>
+        )}
+
+        {/* Re-synthesize — shown when chairman failed */}
         {isSynthesisError && onRetrySynthesis && (
           <button
-            className="retry-synthesis-btn"
+            className="synthesis-ghost-btn"
             onClick={onRetrySynthesis}
             disabled={isLoading}
             title="Re-run the chairman synthesis using existing Stage 1 and Stage 2 data"
           >
-            {isLoading ? (
-              <>
-                <span className="spinner-small"></span>
-                Retrying...
-              </>
-            ) : (
-              <>
-                <RefreshCw size={16} />
-                Retry Synthesis
-              </>
-            )}
+            {isLoading ? <span className="spinner-small" /> : <RotateCw size={14} />}
+            {isLoading ? 'Retrying…' : 'Re-synthesize'}
           </button>
         )}
 
-        {/* One more round button for Arena mode */}
+        {/* One more round — Arena mode only */}
         {isArena && onExtendDebate && (
           <button
-            className="extend-debate-btn"
+            className="synthesis-ghost-btn"
             onClick={onExtendDebate}
             disabled={isExtending}
             title="Add one more deliberation round"
           >
-            {isExtending ? (
-              <>
-                <span className="spinner-small"></span>
-                Extending...
-              </>
-            ) : (
-              <>
-                <Plus size={16} />
-                One More Round
-              </>
-            )}
-          </button>
-        )}
-
-        {/* Continue discussion button */}
-        {onForkConversation && originalQuestion && (
-          <button
-            className="continue-btn"
-            onClick={handleContinueDiscussion}
-            title="Start a new conversation with this context"
-          >
-            <MessageSquarePlus size={16} />
-            Continue Discussion
+            {isExtending ? <span className="spinner-small" /> : <Plus size={14} />}
+            {isExtending ? 'Extending…' : 'One More Round'}
           </button>
         )}
       </div>

--- a/frontend/src/components/VersionInfo.css
+++ b/frontend/src/components/VersionInfo.css
@@ -8,15 +8,21 @@
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   cursor: pointer;
-  transition: background, color;
-  transition-duration: var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .version-trigger:hover {
-  background: var(--color-parchment);
-  color: var(--color-text-secondary);
+  background: var(--surface-hover);
+  color: var(--fg-subtle);
+}
+
+.version-trigger:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
 }
 
 /* Modal Backdrop */
@@ -26,46 +32,25 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(42, 37, 32, 0.5);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  animation: fadeIn 0.2s ease-out;
+  animation: ccFade var(--dur-standard) var(--ease-out);
   -webkit-backface-visibility: hidden;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
 }
 
 /* Modal */
 .version-modal {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
+  background: var(--bg-raised);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--line-strong);
   box-shadow: var(--shadow-lg);
   width: 100%;
   max-width: 360px;
   margin: var(--space-lg);
-  animation: slideUp 0.25s ease-out;
-  -webkit-backface-visibility: hidden;
   overflow: hidden;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 /* Header */
@@ -74,16 +59,16 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-lg);
-  border-bottom: 1px solid var(--color-border);
-  background: linear-gradient(135deg, var(--color-ivory) 0%, var(--color-parchment) 100%);
+  border-bottom: 1px solid var(--line);
 }
 
 .version-header h3 {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
+  font-family: var(--font-head);
+  font-size: 1.125rem;
   font-weight: 600;
   margin: 0;
-  color: var(--color-burgundy);
+  color: var(--fg);
+  letter-spacing: -0.02em;
 }
 
 .version-close {
@@ -94,15 +79,21 @@
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   cursor: pointer;
-  transition: background, color;
-  transition-duration: var(--transition-fast);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .version-close:hover {
-  background: var(--color-parchment);
-  color: var(--color-burgundy);
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.version-close:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
 }
 
 /* Content */
@@ -121,35 +112,36 @@
 
 .version-label {
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 500;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .version-value {
-  font-size: 0.9375rem;
-  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  color: var(--fg);
+  font-family: var(--font-display);
 }
 
 .version-value.mono,
 .version-value .mono {
   font-family: var(--font-mono);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .version-link {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
-  color: var(--color-burgundy);
+  color: var(--accent);
   text-decoration: none;
-  transition: color var(--transition-fast);
+  transition: color var(--dur-micro) var(--ease-out);
 }
 
 .version-link:hover {
-  color: var(--color-burgundy-dark);
+  color: var(--accent-hover);
   text-decoration: underline;
 }
 
@@ -157,20 +149,26 @@
   opacity: 0.7;
 }
 
+.version-link:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 /* Footer */
 .version-footer {
   padding: var(--space-md) var(--space-lg);
-  border-top: 1px solid var(--color-border);
-  background: var(--color-ivory);
+  border-top: 1px solid var(--line);
+  background: var(--bg-sunken);
   text-align: center;
 }
 
 .version-footer span {
   font-family: var(--font-mono);
   font-size: 0.6875rem;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
 }
 
 /* Loading & Error States */
@@ -178,10 +176,11 @@
 .version-error {
   padding: var(--space-xl);
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--fg-subtle);
   font-size: 0.875rem;
+  font-family: var(--font-display);
 }
 
 .version-error {
-  color: var(--color-burgundy);
+  color: var(--danger);
 }

--- a/frontend/src/components/models/FilterChips.jsx
+++ b/frontend/src/components/models/FilterChips.jsx
@@ -27,16 +27,17 @@ export function FilterChips({
   return (
     <div className="filter-bar">
       {showCuratedFilter && curatedCount > 0 && (
-        <label className={`filter-chip curated ${showCuratedOnly ? 'active' : ''}`}>
+        <label className={`filter-chip curated${showCuratedOnly ? ' active' : ''}`}>
           <input
             type="checkbox"
             checked={showCuratedOnly}
             onChange={(e) => setShowCuratedOnly(e.target.checked)}
           />
-          <Star size={12} /> My models ({curatedCount})
+          <Star size={12} aria-hidden="true" /> My models{' '}
+          <span className="fc-count">({curatedCount})</span>
         </label>
       )}
-      <label className={`filter-chip ${showMajorOnly ? 'active' : ''}`}>
+      <label className={`filter-chip${showMajorOnly ? ' active' : ''}`}>
         <input
           type="checkbox"
           checked={showMajorOnly}
@@ -44,7 +45,7 @@ export function FilterChips({
         />
         Major providers
       </label>
-      <label className={`filter-chip ${showFreeOnly ? 'active' : ''}`}>
+      <label className={`filter-chip${showFreeOnly ? ' active' : ''}`}>
         <input
           type="checkbox"
           checked={showFreeOnly}
@@ -53,13 +54,13 @@ export function FilterChips({
         Free only
       </label>
       {!showCuratedFilter && (
-        <label className={`filter-chip ${showCuratedOnly ? 'active' : ''}`}>
+        <label className={`filter-chip${showCuratedOnly ? ' active' : ''}`}>
           <input
             type="checkbox"
             checked={showCuratedOnly}
             onChange={(e) => setShowCuratedOnly(e.target.checked)}
           />
-          <Star size={12} /> Curated only
+          <Star size={12} aria-hidden="true" /> Curated only
         </label>
       )}
       {showContextFilter && (
@@ -79,7 +80,7 @@ export function FilterChips({
           {allProviders.map((provider) => (
             <button
               key={provider}
-              className={`filter-chip provider-chip ${selectedProviders?.has(provider.toLowerCase()) ? 'active' : ''}`}
+              className={`filter-chip provider-chip${selectedProviders?.has(provider.toLowerCase()) ? ' active' : ''}`}
               onClick={() => toggleProvider?.(provider.toLowerCase())}
             >
               {provider}

--- a/frontend/src/components/models/ModelGroups.css
+++ b/frontend/src/components/models/ModelGroups.css
@@ -1,6 +1,6 @@
-/* Model Groups - Shared styles for ModelSelector and ModelCuration */
+/* Model Groups — shared styles for ModelSelector and ModelCuration */
 
-/* Container */
+/* ── Container ──────────────────────────────────────────────────────────── */
 .model-groups {
   display: flex;
   flex-direction: column;
@@ -9,62 +9,64 @@
   min-height: 300px;
   max-height: calc(90vh - 350px);
   overflow-y: auto;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 12px;
-  background: var(--color-ivory);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 10px;
+  background: var(--bg-sunken);
 }
 
-/* Individual Group */
+/* ── Individual group ───────────────────────────────────────────────────── */
 .model-group {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  overflow: visible;
-  background: var(--color-surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-raised);
 }
 
-/* Group Header - Row with toggle button and optional bulk action */
+/* ── Group header ───────────────────────────────────────────────────────── */
 .group-header {
   display: flex;
   align-items: center;
-  background: var(--color-parchment);
+  background: var(--surface);
   border: none;
   width: 100%;
-  min-height: 44px;
-  color: var(--color-text-primary);
+  min-height: 38px;
+  color: var(--fg);
 }
 
 .group-header:hover {
-  background: var(--color-border-light);
+  background: var(--surface-hover);
 }
 
-/* Toggle Button (left side) */
+/* Toggle button (left side) */
 .group-toggle-btn {
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
+  gap: 8px;
+  padding: 8px 12px;
   background: transparent;
   border: none;
   cursor: pointer;
   text-align: left;
-  font-size: 0.9375rem;
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-weight: 600;
-  font-family: var(--font-body);
-  color: var(--color-text-primary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
 }
 
 .group-toggle {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  color: var(--fg-faint);
   width: 14px;
   flex-shrink: 0;
 }
 
 .group-name {
   flex: 1;
-  text-transform: capitalize;
   color: inherit;
 }
 
@@ -75,67 +77,78 @@
 }
 
 .selected-badge {
-  background: var(--color-burgundy);
-  color: white;
-  font-size: 0.6875rem;
-  padding: 2px 8px;
-  border-radius: 10px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 10px;
   font-family: var(--font-mono);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+
+.curated-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: var(--warning-soft);
+  color: var(--warning);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
 }
 
 .total-count {
-  font-size: 0.6875rem;
-  color: var(--color-text-secondary);
+  font-size: 10px;
+  color: var(--fg-faint);
   font-family: var(--font-mono);
-  background: var(--color-border);
-  padding: 2px 8px;
-  border-radius: 10px;
-  min-width: 24px;
+  background: var(--bg-sunken);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  min-width: 22px;
   text-align: center;
 }
 
-/* Bulk Action Button (right side of header) */
+/* Bulk action button (right side of header) */
 .bulk-action-btn {
-  padding: 4px 10px;
+  padding: 3px 9px;
   margin-right: 10px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  font-size: 0.6875rem;
+  font-size: 10px;
+  font-family: var(--font-mono);
   cursor: pointer;
-  color: var(--color-text-secondary);
-  transition: background, border-color, color;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
+  color: var(--fg-subtle);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .bulk-action-btn:hover {
-  background: var(--color-ivory);
-  border-color: var(--color-burgundy);
-  color: var(--color-burgundy);
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
-/* Models Container */
+/* ── Models container ───────────────────────────────────────────────────── */
 .group-models {
   max-height: 40vh;
   overflow-y: auto;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--line);
 }
 
-/* ========================================
-   Checkbox Variant (ModelSelector)
-   ======================================== */
-
+/* ── Checkbox / radio variant (ModelSelector legacy sections) ─────────── */
 .model-option {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 6px 14px;
   cursor: pointer;
-  border-bottom: 1px solid var(--color-border-light);
-  transition: background 0.15s ease;
+  border-bottom: 1px solid var(--line);
+  transition: background var(--dur-micro) var(--ease-out);
   min-height: 32px;
-  background: var(--color-surface);
+  background: var(--bg-raised);
 }
 
 .model-option:last-child {
@@ -143,41 +156,45 @@
 }
 
 .model-option:hover {
-  background: var(--color-ivory);
+  background: var(--surface-hover);
 }
 
-.model-option input[type="checkbox"] {
+.model-option input[type='checkbox'],
+.model-option input[type='radio'] {
   width: 16px;
   height: 16px;
   cursor: pointer;
-  accent-color: var(--color-burgundy);
+  accent-color: var(--accent);
   flex-shrink: 0;
   -webkit-appearance: checkbox;
   appearance: checkbox;
+}
+
+.model-option input[type='radio'] {
+  -webkit-appearance: radio;
+  appearance: radio;
 }
 
 .model-option:empty {
   display: none;
 }
 
-/* ========================================
-   Star Variant (ModelCuration)
-   ======================================== */
-
+/* ── Star / curation variant ────────────────────────────────────────────── */
 .model-item {
   display: flex;
   align-items: center;
   gap: 10px;
   width: 100%;
   padding: 8px 14px;
-  background: var(--color-surface);
+  background: var(--bg-raised);
   border: none;
-  border-bottom: 1px solid var(--color-border-light);
+  border-bottom: 1px solid var(--line);
   cursor: pointer;
   text-align: left;
-  transition: background, border-left, padding-left;
-  transition-duration: 0.15s;
-  transition-timing-function: ease;
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-left-color var(--dur-micro) var(--ease-out),
+    padding-left var(--dur-micro) var(--ease-out);
 }
 
 .model-item:last-child {
@@ -185,52 +202,130 @@
 }
 
 .model-item:hover {
-  background: var(--color-ivory);
+  background: var(--surface-hover);
 }
 
 .model-item.curated {
-  background: linear-gradient(90deg, rgba(139, 38, 53, 0.06) 0%, rgba(139, 38, 53, 0.02) 100%);
-  border-left: 3px solid var(--color-burgundy);
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
   padding-left: 11px;
 }
 
 .model-item.curated:hover {
-  background: linear-gradient(90deg, rgba(139, 38, 53, 0.1) 0%, rgba(139, 38, 53, 0.04) 100%);
+  background: var(--accent-soft);
+  filter: brightness(0.96);
 }
 
-/* Star Icon */
+/* Star icon */
 .star-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 24px;
   height: 24px;
-  border-radius: 4px;
-  color: var(--color-border);
-  transition: color, background;
-  transition-duration: 0.2s;
-  transition-timing-function: ease;
+  border-radius: var(--radius-sm);
+  color: var(--line-strong);
+  transition:
+    color var(--dur-standard) var(--ease-out),
+    background var(--dur-standard) var(--ease-out);
   flex-shrink: 0;
 }
 
 .model-item:hover .star-icon {
-  color: var(--color-gold);
-  background: rgba(196, 164, 105, 0.1);
+  color: var(--warning);
+  background: var(--warning-soft);
 }
 
 .star-icon.active {
-  color: var(--color-burgundy);
-  background: rgba(139, 38, 53, 0.1);
+  color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .model-item:hover .star-icon.active {
-  background: rgba(139, 38, 53, 0.15);
+  background: var(--accent-soft);
+  filter: brightness(0.94);
 }
 
-/* ========================================
-   Shared Model Info Styles
-   ======================================== */
+/* ── Council variant rows ───────────────────────────────────────────────── */
+.ms-model-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px 7px 10px;
+  background: var(--bg-raised);
+  border: none;
+  border-bottom: 1px solid var(--line);
+  border-left: 2px solid transparent;
+  transition: background var(--dur-micro) var(--ease-out);
+}
 
+.ms-model-row:last-child {
+  border-bottom: none;
+}
+
+.ms-model-row:hover {
+  background: var(--surface-hover);
+}
+
+.ms-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background var(--dur-standard) var(--ease-out);
+}
+
+.ms-model-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: var(--font-display);
+  color: var(--fg);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.005em;
+}
+
+.ms-model-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.ms-crown-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--fg-faint);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  transition:
+    color var(--dur-micro) var(--ease-out),
+    background var(--dur-micro) var(--ease-out);
+}
+
+.ms-crown-btn:hover:not(:disabled) {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.ms-crown-btn--active {
+  color: var(--accent);
+}
+
+.ms-crown-btn--active:hover:not(:disabled) {
+  background: var(--accent-soft);
+}
+
+/* ── Shared model info (checkbox / radio / star) ─────────────────────── */
 .model-info {
   display: flex;
   flex-direction: row;
@@ -241,9 +336,9 @@
 }
 
 .model-name {
-  font-size: 0.8125rem;
-  font-family: var(--font-body);
-  color: var(--color-text-primary);
+  font-size: 13px;
+  font-family: var(--font-display);
+  color: var(--fg);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -252,10 +347,10 @@
 }
 
 .model-item.curated .model-name {
-  font-weight: 500;
+  font-weight: 600;
 }
 
-/* Model Meta - Price & Context */
+/* Model meta — price + context */
 .model-meta {
   display: flex;
   align-items: center;
@@ -264,41 +359,41 @@
 }
 
 .model-price {
-  font-size: 0.6875rem;
-  color: var(--color-gold-dark);
+  font-size: 10.5px;
+  color: var(--fg-subtle);
   font-family: var(--font-mono);
-  background: var(--color-stage2);
-  border: 1px solid var(--color-stage2-border);
-  padding: 2px 6px;
-  border-radius: 4px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
-  letter-spacing: -0.02em;
-  min-width: 52px;
+  letter-spacing: -0.01em;
+  min-width: 48px;
   text-align: right;
 }
 
 .model-context {
-  font-size: 0.6875rem;
-  color: var(--color-text-muted);
+  font-size: 10.5px;
+  color: var(--fg-faint);
   font-family: var(--font-mono);
-  background: var(--color-border-light);
-  padding: 2px 6px;
-  border-radius: 4px;
+  background: var(--bg-sunken);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
-  letter-spacing: -0.02em;
-  min-width: 36px;
+  letter-spacing: -0.01em;
+  min-width: 34px;
   text-align: right;
 }
 
-/* Check Icon (for star variant) */
+/* Check icon (star variant) */
 .check-icon {
-  color: var(--color-burgundy);
+  color: var(--accent);
   flex-shrink: 0;
   opacity: 0;
   transform: scale(0.8);
-  transition: opacity, transform;
-  transition-duration: 0.2s;
-  transition-timing-function: ease;
+  transition:
+    opacity var(--dur-standard) var(--ease-out),
+    transform var(--dur-standard) var(--ease-out);
 }
 
 .model-item.curated .check-icon {

--- a/frontend/src/components/models/ModelGroups.jsx
+++ b/frontend/src/components/models/ModelGroups.jsx
@@ -34,7 +34,7 @@ export function ModelItem({
     return (
       <div
         className={`ms-model-row${isSelected ? ' ms-model-row--selected' : ''}`}
-        style={isSelected ? { background: seat.soft, borderLeftColor: seat.color } : {}}
+        style={isSelected ? { background: seat.soft, borderLeftColor: seat.color } : undefined}
       >
         <span
           className="ms-status-dot"
@@ -148,7 +148,7 @@ export function ModelGroupHeader({
 }) {
   return (
     <div className="group-header">
-      <button className="group-toggle-btn" onClick={onToggle}>
+      <button className="group-toggle-btn" onClick={onToggle} aria-expanded={isExpanded}>
         <span className="group-toggle" aria-hidden="true">
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </span>

--- a/frontend/src/components/models/ModelGroups.jsx
+++ b/frontend/src/components/models/ModelGroups.jsx
@@ -1,27 +1,81 @@
-import { Star, Check } from 'lucide-react';
+import { Star, Check, Crown, ChevronDown, ChevronRight } from 'lucide-react';
+import { ToggleSwitch } from '../ui';
 import { formatPrice, getDisplayName, formatContextLength } from '../../lib/models';
 import './ModelGroups.css';
 
 /**
- * Single model item - supports checkbox (selector) and star (curation) variants.
+ * Single model item — supports checkbox (selector), radio (chairman),
+ * star (curation), and council (unified toggle + crown) variants.
  */
 export function ModelItem({
   model,
   isSelected,
   onToggle,
-  variant = 'checkbox', // 'checkbox' | 'radio' | 'star'
+  variant = 'checkbox',
   showContext = false,
   radioName = 'model-radio',
+  // Council variant extras
+  seatOf = null,
+  isChairman = null,
+  onSetChairman = null,
 }) {
   const displayName = getDisplayName(model);
+
+  if (variant === 'council') {
+    const seat = seatOf ? seatOf(model.id) : { color: 'var(--fg-faint)', soft: 'var(--surface)' };
+    const chairman = isChairman ? isChairman(model.id) : false;
+
+    const metaParts = [];
+    if (model.context_length) metaParts.push(formatContextLength(model.context_length));
+    const prompt = formatPrice(model.pricing?.prompt);
+    const completion = formatPrice(model.pricing?.completion);
+    if (prompt || completion) metaParts.push(`${prompt ?? '—'} / ${completion ?? '—'} /M`);
+
+    return (
+      <div
+        className={`ms-model-row${isSelected ? ' ms-model-row--selected' : ''}`}
+        style={isSelected ? { background: seat.soft, borderLeftColor: seat.color } : {}}
+      >
+        <span
+          className="ms-status-dot"
+          style={{ background: isSelected ? seat.color : 'var(--fg-faint)' }}
+        />
+        <span className="ms-model-name" title={model.id}>
+          {displayName}
+        </span>
+        {metaParts.length > 0 && <span className="ms-model-meta">{metaParts.join(' · ')}</span>}
+        <button
+          className={`ms-crown-btn${chairman ? ' ms-crown-btn--active' : ''}`}
+          style={!isSelected ? { opacity: 0.35, cursor: 'not-allowed' } : {}}
+          disabled={!isSelected}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (isSelected && onSetChairman) onSetChairman(model.id);
+          }}
+          title={
+            chairman ? 'Current chairman' : isSelected ? 'Set as chairman' : 'Select model first'
+          }
+          aria-label={chairman ? 'Chairman' : 'Set as chairman'}
+        >
+          <Crown size={14} fill={chairman ? 'currentColor' : 'none'} strokeWidth={2} />
+        </button>
+        <ToggleSwitch
+          checked={isSelected}
+          onChange={() => onToggle(model.id)}
+          color={seat.color}
+          ariaLabel={`Toggle ${displayName}`}
+        />
+      </div>
+    );
+  }
 
   if (variant === 'star') {
     return (
       <button
-        className={`model-item ${isSelected ? 'curated' : ''}`}
+        className={`model-item${isSelected ? ' curated' : ''}`}
         onClick={() => onToggle(model.id)}
       >
-        <span className={`star-icon ${isSelected ? 'active' : ''}`}>
+        <span className={`star-icon${isSelected ? ' active' : ''}`}>
           <Star size={16} fill={isSelected ? 'currentColor' : 'none'} />
         </span>
         <span className="model-info">
@@ -31,9 +85,7 @@ export function ModelItem({
           <span className="model-meta">
             <span className="model-price">{formatPrice(model.pricing?.completion)}</span>
             {showContext && model.context_length && (
-              <span className="model-context">
-                {formatContextLength(model.context_length)}
-              </span>
+              <span className="model-context">{formatContextLength(model.context_length)}</span>
             )}
           </span>
         </span>
@@ -59,9 +111,7 @@ export function ModelItem({
           <span className="model-meta">
             <span className="model-price">{formatPrice(model.pricing?.completion)}</span>
             {showContext && model.context_length > 0 && (
-              <span className="model-context">
-                {formatContextLength(model.context_length)}
-              </span>
+              <span className="model-context">{formatContextLength(model.context_length)}</span>
             )}
           </span>
         </span>
@@ -72,11 +122,7 @@ export function ModelItem({
   // Checkbox variant (default)
   return (
     <label className="model-option">
-      <input
-        type="checkbox"
-        checked={isSelected}
-        onChange={() => onToggle(model.id)}
-      />
+      <input type="checkbox" checked={isSelected} onChange={() => onToggle(model.id)} />
       <span className="model-info">
         <span className="model-name" title={model.id}>
           {displayName}
@@ -98,31 +144,29 @@ export function ModelGroupHeader({
   totalCount,
   showSelectedBadge = false,
   showCuratedBadge = false,
-  bulkAction = null, // { label, onClick }
+  bulkAction = null,
 }) {
   return (
     <div className="group-header">
       <button className="group-toggle-btn" onClick={onToggle}>
-        <span className="group-toggle">{isExpanded ? '▼' : '▶'}</span>
+        <span className="group-toggle" aria-hidden="true">
+          {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
         <span className="group-name">{provider}</span>
         <span className="group-count">
           {showSelectedBadge && selectedCount > 0 && (
-            <span className="selected-badge">{selectedCount} selected</span>
+            <span className="selected-badge">{selectedCount}</span>
           )}
           {showCuratedBadge && selectedCount > 0 && (
             <span className="curated-badge">
-              <Star size={10} /> {selectedCount}
+              <Star size={10} aria-hidden="true" /> {selectedCount}
             </span>
           )}
           <span className="total-count">{totalCount}</span>
         </span>
       </button>
       {isExpanded && bulkAction && (
-        <button
-          className="bulk-action-btn"
-          onClick={bulkAction.onClick}
-          title={bulkAction.title}
-        >
+        <button className="bulk-action-btn" onClick={bulkAction.onClick} title={bulkAction.title}>
           {bulkAction.label}
         </button>
       )}
@@ -145,41 +189,50 @@ export function ModelGroups({
   getSelectedCount = () => 0,
   getBulkAction = null,
   radioName = 'model-radio',
+  // Council variant extras
+  seatOf = null,
+  isChairman = null,
+  onSetChairman = null,
 }) {
   return (
     <div className="model-groups">
-      {sortedProviders.map(provider => {
+      {sortedProviders.map((provider) => {
         const expanded = isExpanded(provider);
         const providerModels = groupedModels[provider];
         const selectedCount = getSelectedCount(provider);
         const bulkAction = getBulkAction?.(provider, providerModels);
 
         return (
-          <div key={provider} className={`model-group ${expanded ? 'expanded' : ''}`}>
+          <div key={provider} className={`model-group${expanded ? ' expanded' : ''}`}>
             <ModelGroupHeader
               provider={provider}
               isExpanded={expanded}
               onToggle={() => onToggleProvider(provider)}
               selectedCount={selectedCount}
               totalCount={providerModels.length}
-              showSelectedBadge={variant === 'checkbox'}
+              showSelectedBadge={variant === 'checkbox' || variant === 'council'}
               showCuratedBadge={variant === 'star'}
               bulkAction={bulkAction}
             />
 
             {expanded && (
               <div className="group-models">
-                {providerModels.filter(m => m.id).map(model => (
-                  <ModelItem
-                    key={model.id}
-                    model={model}
-                    isSelected={isSelected(model.id)}
-                    onToggle={onToggleModel}
-                    variant={variant}
-                    showContext={showContext}
-                    radioName={radioName}
-                  />
-                ))}
+                {providerModels
+                  .filter((m) => m.id)
+                  .map((model) => (
+                    <ModelItem
+                      key={model.id}
+                      model={model}
+                      isSelected={isSelected(model.id)}
+                      onToggle={onToggleModel}
+                      variant={variant}
+                      showContext={showContext}
+                      radioName={radioName}
+                      seatOf={seatOf}
+                      isChairman={isChairman}
+                      onSetChairman={onSetChairman}
+                    />
+                  ))}
               </div>
             )}
           </div>

--- a/frontend/src/components/models/ModelSearchBox.jsx
+++ b/frontend/src/components/models/ModelSearchBox.jsx
@@ -4,30 +4,29 @@ import { Search, X } from 'lucide-react';
 /**
  * Search input with clear button for filtering models.
  */
-export const ModelSearchBox = forwardRef(function ModelSearchBox({
-  value,
-  onChange,
-  placeholder = 'Search models...',
-  showIcon = false,
-}, ref) {
+export const ModelSearchBox = forwardRef(function ModelSearchBox(
+  { value, onChange, placeholder = 'Search models or providers…', showIcon = true },
+  ref
+) {
   return (
     <div className="search-box">
-      {showIcon && <Search size={16} className="search-icon" />}
+      {showIcon && <Search size={14} className="search-icon" aria-hidden="true" />}
       <input
         ref={ref}
         type="text"
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="search-input"
+        className={`search-input${showIcon ? ' search-input--icon' : ''}`}
       />
       {value && (
         <button
           className="search-clear"
           onClick={() => onChange('')}
           title="Clear search"
+          aria-label="Clear search"
         >
-          {showIcon ? <X size={14} /> : '×'}
+          <X size={14} />
         </button>
       )}
     </div>

--- a/frontend/src/components/sidebar/ConversationItem.jsx
+++ b/frontend/src/components/sidebar/ConversationItem.jsx
@@ -1,8 +1,28 @@
 import { useState, useRef, useEffect } from 'react';
 import { Pencil, Trash2, Download } from 'lucide-react';
+import { useSeatColors } from '../../hooks/useSeatColors';
+
+/**
+ * Format a creation timestamp as a relative-time string: "3m ago", "2h ago", "4d ago".
+ */
+function formatRelativeTime(iso) {
+  if (!iso) return '';
+  try {
+    const diff = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.floor(hrs / 24)}d ago`;
+  } catch {
+    return '';
+  }
+}
 
 /**
  * Single conversation item with rename/delete/export functionality.
+ * Row layout: seat dot + title on line 1; mode · relative-time on line 2.
  */
 export function ConversationItem({
   conversation,
@@ -18,6 +38,12 @@ export function ConversationItem({
   const [showExportMenu, setShowExportMenu] = useState(false);
   const inputRef = useRef(null);
   const exportMenuRef = useRef(null);
+  const { seatOf } = useSeatColors();
+
+  // Derive a stable seat color: prefer conversation's model info, fall back to conversation id.
+  const modelId =
+    conversation.chairman_model ?? conversation.council_models?.[0] ?? conversation.id;
+  const seat = seatOf(modelId);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -114,11 +140,7 @@ export function ConversationItem({
             >
               Yes
             </button>
-            <button
-              className="confirm-btn confirm-no"
-              onClick={handleCancelDelete}
-              title="Cancel"
-            >
+            <button className="confirm-btn confirm-no" onClick={handleCancelDelete} title="Cancel">
               No
             </button>
           </div>
@@ -145,59 +167,51 @@ export function ConversationItem({
     );
   }
 
-  // Default state
+  // Default state — two-line row
   return (
-    <div
-      className={`conversation-item ${isActive ? 'active' : ''}`}
-      onClick={handleClick}
-    >
+    <div className={`conversation-item ${isActive ? 'active' : ''}`} onClick={handleClick}>
       <div className="conversation-content">
-        <div className="conversation-title">
-          {conversation.title || 'New Conversation'}
+        <div className="conversation-row-1">
+          <span
+            className="conversation-seat-dot"
+            style={{ background: seat.color }}
+            aria-hidden="true"
+          />
+          <span className="conversation-title">{conversation.title || 'New Conversation'}</span>
         </div>
-        <div className="conversation-meta">
-          {conversation.message_count} messages
+        <div className="conversation-row-2">
+          {conversation.mode ? (
+            <>
+              <span className="conversation-mode">{conversation.mode}</span>
+              <span className="conversation-sep" aria-hidden="true">
+                ·
+              </span>
+            </>
+          ) : null}
+          <span className="conversation-time">{formatRelativeTime(conversation.created_at)}</span>
         </div>
       </div>
       <div className="conversation-actions">
-        <button
-          className="action-btn"
-          onClick={handleStartRename}
-          title="Rename"
-        >
-          <Pencil size={14} />
+        <button className="action-btn" onClick={handleStartRename} title="Rename">
+          <Pencil size={13} />
         </button>
         <div className="export-menu-container" ref={exportMenuRef}>
-          <button
-            className="action-btn"
-            onClick={handleExportClick}
-            title="Export"
-          >
-            <Download size={14} />
+          <button className="action-btn" onClick={handleExportClick} title="Export">
+            <Download size={13} />
           </button>
           {showExportMenu && (
             <div className="export-menu">
-              <button
-                className="export-menu-item"
-                onClick={() => handleExport('markdown')}
-              >
+              <button className="export-menu-item" onClick={() => handleExport('markdown')}>
                 Export as Markdown
               </button>
-              <button
-                className="export-menu-item"
-                onClick={() => handleExport('json')}
-              >
+              <button className="export-menu-item" onClick={() => handleExport('json')}>
                 Export as JSON
               </button>
             </div>
           )}
         </div>
-        <button
-          className="action-btn action-delete"
-          onClick={handleDeleteClick}
-          title="Delete"
-        >
-          <Trash2 size={14} />
+        <button className="action-btn action-delete" onClick={handleDeleteClick} title="Delete">
+          <Trash2 size={13} />
         </button>
       </div>
     </div>

--- a/frontend/src/components/sidebar/CouncilDisplay.css
+++ b/frontend/src/components/sidebar/CouncilDisplay.css
@@ -1,29 +1,12 @@
-/* Council Panel - Distinguished Roster */
+/* Council Panel */
 .council-panel {
   position: relative;
   margin: var(--space-sm);
-  background: linear-gradient(
-    135deg,
-    var(--color-ivory) 0%,
-    var(--color-cream) 100%
-  );
+  background: var(--bg-raised);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--line);
   overflow: hidden;
-  box-shadow:
-    var(--shadow-subtle),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6);
-}
-
-/* Decorative accent bar */
-.council-panel-accent {
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    var(--color-gold-dark) 0%,
-    var(--color-gold) 50%,
-    var(--color-gold-dark) 100%
-  );
+  box-shadow: var(--shadow-sm);
 }
 
 /* Header */
@@ -43,22 +26,18 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--color-text-primary);
-  transition: color var(--transition-fast);
+  color: var(--fg);
+  transition: color var(--dur-micro) var(--ease-out);
 }
 
 .council-panel-toggle:hover {
-  color: var(--color-burgundy);
+  color: var(--accent);
 }
 
 .council-panel-toggle:focus-visible {
-  outline: none;
-}
-
-.council-panel-toggle:focus-visible .council-panel-title {
-  text-decoration: underline;
-  text-decoration-color: var(--color-burgundy);
-  text-underline-offset: 2px;
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 .council-panel-title {
@@ -68,11 +47,11 @@
   font-family: var(--font-display);
   font-size: 0.875rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.005em;
 }
 
 .council-icon {
-  color: var(--color-gold-dark);
+  color: var(--accent);
 }
 
 .council-count {
@@ -82,8 +61,8 @@
   min-width: 20px;
   height: 20px;
   padding: 0 6px;
-  background: var(--color-burgundy);
-  color: #fff;
+  background: var(--accent-soft);
+  color: var(--accent);
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   font-weight: 600;
@@ -91,8 +70,8 @@
 }
 
 .council-chevron {
-  color: var(--color-text-muted);
-  transition: transform var(--transition-medium);
+  color: var(--fg-faint);
+  transition: transform var(--dur-standard) var(--ease-out);
 }
 
 .council-chevron.expanded {
@@ -114,31 +93,32 @@
   padding: 0;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  color: var(--color-text-muted);
-  transition: background, border-color, color;
-  transition-duration: var(--transition-fast);
+  color: var(--fg-faint);
+  transition:
+    background var(--dur-micro) var(--ease-out),
+    border-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out);
 }
 
 .council-action-btn:hover {
-  background: var(--color-surface);
-  border-color: var(--color-border-light);
-  color: var(--color-text-primary);
+  background: var(--surface-hover);
+  border-color: var(--line);
+  color: var(--fg);
 }
 
 .council-action-btn.curate:hover {
-  color: var(--color-gold-dark);
-  border-color: var(--color-gold-light);
+  color: var(--warning);
 }
 
 .council-action-btn.configure:hover {
-  color: var(--color-burgundy);
-  border-color: rgba(139, 38, 53, 0.2);
+  color: var(--accent);
+  border-color: var(--accent-ring);
 }
 
 .council-action-btn:focus-visible {
-  outline: 2px solid var(--color-burgundy);
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
@@ -153,24 +133,19 @@
   font-family: var(--font-mono);
   font-size: 0.625rem;
   font-weight: 600;
-  color: var(--color-text-muted);
-  transition: color;
-  transition-duration: var(--transition-fast);
+  color: var(--fg-faint);
+  transition: color var(--dur-micro) var(--ease-out);
 }
 
 .council-action-btn.configure:hover .config-model-count {
-  color: var(--color-burgundy);
+  color: var(--accent);
 }
 
 /* Collapsible Content */
 .council-panel-content {
   overflow: hidden;
-  transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: max-height var(--dur-deliberate) var(--ease-out);
   padding: 0 var(--space-md);
-}
-
-.council-panel-content.animating {
-  overflow: hidden;
 }
 
 /* Section Labels */
@@ -184,9 +159,9 @@
   font-size: 0.625rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-muted);
-  border-bottom: 1px dashed var(--color-border-light);
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
+  border-bottom: 1px solid var(--line);
 }
 
 /* Chairman Section */
@@ -196,12 +171,12 @@
 }
 
 .council-chairman-section .council-section-label {
-  color: var(--color-gold-dark);
-  border-bottom-color: var(--color-gold-light);
+  color: var(--accent);
+  border-bottom-color: var(--accent-soft);
 }
 
 .council-chairman-section .council-section-label svg {
-  color: var(--color-gold);
+  color: var(--accent);
 }
 
 /* Members Section */
@@ -222,11 +197,9 @@
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-sm);
   background: transparent;
-  border-radius: var(--radius-md);
-  transition:
-    background var(--transition-fast),
-    transform var(--transition-fast);
-  animation: memberSlideIn 0.3s ease-out backwards;
+  border-radius: var(--radius-sm);
+  transition: background var(--dur-micro) var(--ease-out);
+  animation: memberSlideIn var(--dur-standard) var(--ease-out) backwards;
   -webkit-backface-visibility: hidden;
 }
 
@@ -242,39 +215,7 @@
 }
 
 .council-member:hover {
-  background: var(--color-surface);
-}
-
-/* Member Indicator Dot */
-.member-indicator {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-sage);
-  border: 2px solid var(--color-text-muted);
-  flex-shrink: 0;
-  transition: border-color, background, box-shadow;
-  transition-duration: var(--transition-fast);
-}
-
-.council-member:hover .member-indicator {
-  border-color: var(--color-burgundy);
-  background: rgba(139, 38, 53, 0.1);
-}
-
-/* Chairman Indicator - Gold Ring */
-.member-indicator.chairman {
-  background: var(--color-gold);
-  border-color: var(--color-gold-dark);
-  box-shadow:
-    0 0 0 2px var(--color-ivory),
-    0 0 0 3px var(--color-gold-light);
-}
-
-.council-member.chairman:hover .member-indicator.chairman {
-  box-shadow:
-    0 0 0 2px var(--color-surface),
-    0 0 0 4px var(--color-gold);
+  background: var(--surface-hover);
 }
 
 /* Member Name */
@@ -283,7 +224,7 @@
   font-family: var(--font-mono);
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--color-text-primary);
+  color: var(--fg);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -291,7 +232,7 @@
 
 .council-member.chairman .member-name {
   font-weight: 600;
-  color: var(--color-gold-dark);
+  color: var(--accent);
 }
 
 /* Provider Badge */
@@ -299,13 +240,13 @@
   font-family: var(--font-mono);
   font-size: 0.625rem;
   font-weight: 500;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   padding: 2px 6px;
-  background: var(--color-parchment);
+  background: var(--bg-sunken);
   border-radius: var(--radius-sm);
   text-transform: lowercase;
-  opacity: 0.7;
-  transition: opacity var(--transition-fast);
+  opacity: 0.8;
+  transition: opacity var(--dur-micro) var(--ease-out);
 }
 
 .council-member:hover .member-provider {
@@ -313,71 +254,19 @@
 }
 
 .council-member.chairman .member-provider {
-  background: var(--color-gold-light);
-  color: var(--color-gold-dark);
+  background: var(--accent-soft);
+  color: var(--accent);
+  opacity: 1;
 }
 
 /* Footnote */
 .council-footnote {
   padding: var(--space-sm) 0;
   margin-top: var(--space-xs);
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-size: 0.6875rem;
   font-style: italic;
-  color: var(--color-text-muted);
+  color: var(--fg-faint);
   text-align: center;
-  border-top: 1px dotted var(--color-border-light);
-}
-
-/* Dark Mode Adjustments */
-:root[data-theme="dark"] .council-panel {
-  background: linear-gradient(
-    135deg,
-    var(--color-parchment) 0%,
-    var(--color-ivory) 100%
-  );
-  box-shadow:
-    var(--shadow-subtle),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-:root[data-theme="dark"] .council-panel-accent {
-  background: linear-gradient(
-    90deg,
-    var(--color-gold-dark) 0%,
-    var(--color-gold) 50%,
-    var(--color-gold-dark) 100%
-  );
-}
-
-:root[data-theme="dark"] .council-count {
-  background: var(--color-burgundy);
-}
-
-:root[data-theme="dark"] .member-indicator {
-  background: var(--color-ivory);
-  border-color: var(--color-text-muted);
-}
-
-:root[data-theme="dark"] .member-indicator.chairman {
-  background: var(--color-gold);
-  border-color: var(--color-gold-dark);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .council-panel {
-    background: linear-gradient(
-      135deg,
-      var(--color-parchment) 0%,
-      var(--color-ivory) 100%
-    );
-    box-shadow:
-      var(--shadow-subtle),
-      inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  }
-
-  :root:not([data-theme="light"]) .member-indicator {
-    background: var(--color-ivory);
-    border-color: var(--color-text-muted);
-  }
+  border-top: 1px dashed var(--line);
 }

--- a/frontend/src/components/sidebar/CouncilDisplay.jsx
+++ b/frontend/src/components/sidebar/CouncilDisplay.jsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Star, Settings, ChevronDown, Crown, Users } from 'lucide-react';
+import { SeatAvatar } from '../ui';
+import { useSeatColors } from '../../hooks/useSeatColors';
 import './CouncilDisplay.css';
 
 /**
@@ -20,17 +22,13 @@ function getProvider(model) {
 }
 
 /**
- * Council members display - Distinguished roster panel.
+ * Council members display — seat-colored roster panel.
  */
-export function CouncilDisplay({
-  councilModels,
-  chairmanModel,
-  onOpenConfig,
-  onOpenCuration,
-}) {
+export function CouncilDisplay({ councilModels, chairmanModel, onOpenConfig, onOpenCuration }) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
   const contentRef = useRef(null);
+  const { seatOf } = useSeatColors();
 
   // Handle expand/collapse animation
   useEffect(() => {
@@ -59,25 +57,15 @@ export function CouncilDisplay({
 
   return (
     <div className="council-panel">
-      {/* Decorative top border */}
-      <div className="council-panel-accent" />
-
       {/* Header */}
       <div className="council-panel-header">
-        <button
-          className="council-panel-toggle"
-          onClick={handleToggle}
-          aria-expanded={isExpanded}
-        >
+        <button className="council-panel-toggle" onClick={handleToggle} aria-expanded={isExpanded}>
           <div className="council-panel-title">
             <Users size={14} className="council-icon" />
             <span>The Council</span>
             <span className="council-count">{councilModels.length}</span>
           </div>
-          <ChevronDown
-            size={16}
-            className={`council-chevron ${isExpanded ? 'expanded' : ''}`}
-          />
+          <ChevronDown size={16} className={`council-chevron ${isExpanded ? 'expanded' : ''}`} />
         </button>
 
         <div className="council-panel-actions">
@@ -100,10 +88,7 @@ export function CouncilDisplay({
       </div>
 
       {/* Members List */}
-      <div
-        ref={contentRef}
-        className={`council-panel-content ${isAnimating ? 'animating' : ''}`}
-      >
+      <div ref={contentRef} className={`council-panel-content ${isAnimating ? 'animating' : ''}`}>
         {/* Chairman Section */}
         {chairmanModel && (
           <div className="council-chairman-section">
@@ -112,7 +97,11 @@ export function CouncilDisplay({
               <span>Chairman</span>
             </div>
             <div className="council-member chairman" title={chairmanModel}>
-              <div className="member-indicator chairman" />
+              <SeatAvatar
+                color={seatOf(chairmanModel).color}
+                name={getShortModelName(chairmanModel)}
+                size={20}
+              />
               <span className="member-name">{getShortModelName(chairmanModel)}</span>
               <span className="member-provider">{getProvider(chairmanModel)}</span>
             </div>
@@ -134,7 +123,11 @@ export function CouncilDisplay({
                   title={model}
                   style={{ animationDelay: `${idx * 50}ms` }}
                 >
-                  <div className="member-indicator" />
+                  <SeatAvatar
+                    color={seatOf(model).color}
+                    name={getShortModelName(model)}
+                    size={20}
+                  />
                   <span className="member-name">{getShortModelName(model)}</span>
                   <span className="member-provider">{getProvider(model)}</span>
                 </div>
@@ -145,9 +138,7 @@ export function CouncilDisplay({
 
         {/* Chairman also as member indicator */}
         {chairmanInCouncil && regularMembers.length > 0 && (
-          <div className="council-footnote">
-            Chairman also participates as council member
-          </div>
+          <div className="council-footnote">Chairman also participates as council member</div>
         )}
       </div>
     </div>

--- a/frontend/src/components/ui/BrandMark.jsx
+++ b/frontend/src/components/ui/BrandMark.jsx
@@ -1,0 +1,39 @@
+/**
+ * BrandMark — the LLM Council logo: three descending horizontal bars (a
+ * "ranking" motif tying the mark to the app's peer-review signature) inside an
+ * ember rounded square.
+ *
+ * @param {number} [size=30] - square edge in px
+ */
+export default function BrandMark({ size = 30 }) {
+  const bar = (width, opacity) => ({
+    height: '2.5px',
+    width: `${width}px`,
+    borderRadius: '2px',
+    background: 'var(--fg-on-accent)',
+    opacity,
+  });
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        flex: 'none',
+        borderRadius: '8px',
+        background: 'var(--accent)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        gap: '3px',
+        padding: '0 8px',
+        boxShadow: 'var(--shadow-sm)',
+      }}
+    >
+      <span style={bar(14, 1)} />
+      <span style={bar(9, 0.68)} />
+      <span style={bar(5, 0.45)} />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/KpiCard.jsx
+++ b/frontend/src/components/ui/KpiCard.jsx
@@ -1,0 +1,48 @@
+/**
+ * KpiCard — a Standings KPI tile: a mono uppercase micro-label, a big mono
+ * value, and an optional subline.
+ *
+ * @param {string} label - uppercase micro-label
+ * @param {string|number} value - the headline figure (rendered mono)
+ * @param {string} [sub] - small supporting line
+ */
+export default function KpiCard({ label, value, sub }) {
+  return (
+    <div
+      style={{
+        background: 'var(--bg-raised)',
+        border: '1px solid var(--line)',
+        borderRadius: '12px',
+        padding: '16px',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '10px',
+          fontFamily: 'var(--font-mono)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--fg-faint)',
+          marginBottom: '8px',
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: '26px',
+          fontWeight: 700,
+          fontFamily: 'var(--font-mono)',
+          letterSpacing: '-0.02em',
+          color: 'var(--fg)',
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </div>
+      {sub != null && (
+        <div style={{ fontSize: '11px', color: 'var(--fg-subtle)', marginTop: '6px' }}>{sub}</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/SeatAvatar.jsx
+++ b/frontend/src/components/ui/SeatAvatar.jsx
@@ -1,0 +1,46 @@
+/**
+ * SeatAvatar — a rounded-square avatar in a model's seat color with a mono
+ * initial. Used in the landing seat row, Stage-1 panel, Standings rows, Arena
+ * cards, and the sidebar council display.
+ *
+ * @param {string} color - seat color, e.g. 'var(--seat-2)' (defaults to seat 1)
+ * @param {string} [initial] - single glyph; derived from `name` when omitted
+ * @param {string} [name] - full model name (for initial + title fallback)
+ * @param {number} [size=26] - square edge in px
+ */
+export default function SeatAvatar({
+  color = 'var(--seat-1)',
+  initial,
+  name,
+  size = 26,
+  title,
+  style,
+  className,
+}) {
+  const glyph = initial ?? (name ? name.trim()[0]?.toUpperCase() : '?');
+  const px = `${size}px`;
+  return (
+    <span
+      className={className}
+      title={title ?? name}
+      style={{
+        width: px,
+        height: px,
+        flex: 'none',
+        borderRadius: '7px',
+        background: color,
+        color: '#fff',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: 'var(--font-mono)',
+        fontSize: `${Math.round(size * 0.42)}px`,
+        fontWeight: 700,
+        lineHeight: 1,
+        ...style,
+      }}
+    >
+      {glyph}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/SeatAvatar.jsx
+++ b/frontend/src/components/ui/SeatAvatar.jsx
@@ -23,13 +23,15 @@ export default function SeatAvatar({
     <span
       className={className}
       title={title ?? name}
+      aria-label={title ?? name}
+      role="img"
       style={{
         width: px,
         height: px,
         flex: 'none',
         borderRadius: '7px',
         background: color,
-        color: '#fff',
+        color: 'var(--fg-on-accent)',
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/frontend/src/components/ui/StageRail.jsx
+++ b/frontend/src/components/ui/StageRail.jsx
@@ -40,7 +40,7 @@ export default function StageRail({ stages = [], completedCount = 0, size = 26, 
           border: complete ? 'none' : '2px solid var(--line-strong)',
         };
         return (
-          <div key={i} style={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0 }}>
+          <div key={label} style={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0 }}>
             <div
               style={{
                 display: 'flex',

--- a/frontend/src/components/ui/StageRail.jsx
+++ b/frontend/src/components/ui/StageRail.jsx
@@ -1,0 +1,94 @@
+import { Check } from 'lucide-react';
+
+/**
+ * StageRail — connected stage nodes driven by completed-stage state.
+ *
+ * Council: 3 stages (First opinions / Peer review / Synthesis).
+ * Arena: 4 stages (Opening / Rebuttal / Closing / Verdict).
+ *
+ * Completed nodes fill with `--fg-subtle` and a check; the final node fills
+ * ember when complete. Pending nodes show their number with a hairline ring.
+ * Render this inside a `--bg-raised` card (the consumer owns the card chrome).
+ *
+ * @param {(string | { label: string, sublabel?: string })[]} stages
+ * @param {number} [completedCount=0] - how many leading stages are done
+ * @param {number} [size=26] - node diameter in px
+ * @param {number} [gap=12] - connector-line margin in px
+ */
+export default function StageRail({ stages = [], completedCount = 0, size = 26, gap = 12 }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+      {stages.map((st, i) => {
+        const label = typeof st === 'string' ? st : st.label;
+        const sublabel = typeof st === 'string' ? null : st.sublabel;
+        const isLast = i === stages.length - 1;
+        const complete = i < completedCount;
+        const ember = isLast && complete;
+        const node = {
+          width: `${size}px`,
+          height: `${size}px`,
+          flex: 'none',
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'var(--font-mono)',
+          fontSize: `${Math.round(size * 0.46)}px`,
+          fontWeight: 700,
+          background: complete ? (ember ? 'var(--accent)' : 'var(--fg-subtle)') : 'transparent',
+          color: complete ? (ember ? 'var(--fg-on-accent)' : 'var(--bg)') : 'var(--fg-faint)',
+          border: complete ? 'none' : '2px solid var(--line-strong)',
+        };
+        return (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: sublabel ? '9px' : '8px',
+                flex: 'none',
+              }}
+            >
+              <span style={node}>
+                {complete ? <Check size={Math.round(size * 0.5)} strokeWidth={3} /> : i + 1}
+              </span>
+              {sublabel ? (
+                <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.15 }}>
+                  <span
+                    style={{
+                      fontSize: '9.5px',
+                      fontFamily: 'var(--font-mono)',
+                      color: 'var(--fg-faint)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    {sublabel}
+                  </span>
+                  <span style={{ fontSize: '12.5px', fontWeight: 600, color: 'var(--fg)' }}>
+                    {label}
+                  </span>
+                </div>
+              ) : (
+                <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--fg)' }}>
+                  {label}
+                </span>
+              )}
+            </div>
+            {!isLast && (
+              <div
+                style={{
+                  flex: 1,
+                  height: '2px',
+                  background: 'var(--line-strong)',
+                  margin: `0 ${gap}px`,
+                  minWidth: `${gap + 6}px`,
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ToggleSwitch.jsx
+++ b/frontend/src/components/ui/ToggleSwitch.jsx
@@ -1,0 +1,59 @@
+/**
+ * ToggleSwitch — 38x22 track with a 16px knob sliding 2<->18px. The "on" color
+ * is the model's seat / provider color so the control reads in-palette.
+ *
+ * @param {boolean} checked
+ * @param {(next: boolean) => void} onChange
+ * @param {string} [color='var(--accent)'] - track color when on
+ * @param {boolean} [disabled]
+ * @param {string} [ariaLabel]
+ */
+export default function ToggleSwitch({
+  checked = false,
+  onChange,
+  color = 'var(--accent)',
+  disabled = false,
+  ariaLabel,
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!disabled) onChange?.(!checked);
+      }}
+      style={{
+        width: '38px',
+        height: '22px',
+        flex: 'none',
+        padding: 0,
+        borderRadius: '999px',
+        background: checked ? color : 'var(--bg-sunken)',
+        border: `1px solid ${checked ? color : 'var(--line-strong)'}`,
+        position: 'relative',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+        transition:
+          'background var(--dur-standard) var(--ease-out), border-color var(--dur-standard) var(--ease-out)',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          top: '2px',
+          left: checked ? '18px' : '2px',
+          width: '16px',
+          height: '16px',
+          borderRadius: '50%',
+          background: '#fff',
+          boxShadow: 'var(--shadow-sm)',
+          transition: 'left var(--dur-standard) var(--ease-out)',
+        }}
+      />
+    </button>
+  );
+}

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -1,0 +1,5 @@
+export { default as SeatAvatar } from './SeatAvatar';
+export { default as BrandMark } from './BrandMark';
+export { default as StageRail } from './StageRail';
+export { default as ToggleSwitch } from './ToggleSwitch';
+export { default as KpiCard } from './KpiCard';

--- a/frontend/src/hooks/useSeatColors.js
+++ b/frontend/src/hooks/useSeatColors.js
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { assignSeats, seatTokens, rawSeat } from '../lib/seatColors';
+import { useConfig } from './queries';
+
+// Stable empty reference so an unloaded config doesn't churn the memo.
+const EMPTY_IDS = [];
+
+/**
+ * Seat-color assignment for the current council.
+ *
+ * Returns `seatOf(modelId)` -> `{ seat, color, soft }`, where `color`/`soft`
+ * are CSS `var(--seat-N*)` strings. Seats are assigned over the active council
+ * (`config.council_models`); a non-council id falls back to its raw hashed seat
+ * so any model still renders a stable color.
+ *
+ * @param {string[]} [councilIdsOverride] - optional explicit roster (e.g. a
+ *   conversation's own council) instead of the live config.
+ */
+export function useSeatColors(councilIdsOverride) {
+  const configQuery = useConfig();
+  const councilIds = councilIdsOverride ?? configQuery.data?.council_models ?? EMPTY_IDS;
+
+  const seatMap = useMemo(() => assignSeats(councilIds), [councilIds]);
+
+  return useMemo(
+    () => ({
+      seatMap,
+      seatOf(modelId) {
+        if (modelId == null) return seatTokens(1);
+        const key = String(modelId);
+        return seatMap.get(key) ?? seatTokens(rawSeat(key));
+      },
+    }),
+    [seatMap]
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,59 +6,61 @@
 
 :root {
   /* ── Neutrals & surfaces (light) ─────────────────────────────────────── */
-  --bg: #EBEAE5;
-  --bg-raised: #F7F6F3;
-  --bg-sunken: #E3E2DC;
-  --surface: #FBFAF8;
-  --surface-hover: #EDECE7;
+  --bg: #ebeae5;
+  --bg-raised: #f7f6f3;
+  --bg-sunken: #e3e2dc;
+  --surface: #fbfaf8;
+  --surface-hover: #edece7;
 
-  --fg: #14161A;
-  --fg-muted: #363A42;
-  --fg-subtle: #6A6F7A;
-  --fg-faint: #8E939E;
-  --fg-on-accent: #FFFFFF;
+  --fg: #14161a;
+  --fg-muted: #363a42;
+  --fg-subtle: #6a6f7a;
+  --fg-faint: #8e939e;
+  --fg-on-accent: #ffffff;
 
-  --line: #DBDAD2;
-  --line-strong: #C7C6BD;
+  --line: #dbdad2;
+  --line-strong: #c7c6bd;
 
   /* ── Accent — ember (primary CTAs, chairman synthesis/verdict, brand) ── */
-  --accent: #D76A3A;
-  --accent-hover: #BC5528;
-  --accent-soft: #FBEEE6;
-  --accent-ring: rgba(215, 106, 58, .4);
+  --accent: #d76a3a;
+  --accent-hover: #bc5528;
+  --accent-soft: #fbeee6;
+  --accent-ring: rgba(215, 106, 58, 0.4);
 
   /* ── Seat / model identity palette (the signature) ───────────────────── */
-  --seat-1: #3F6C85;
-  --seat-2: #4C8A58;
-  --seat-3: #B68430;
-  --seat-4: #7C5A86;
-  --seat-5: #4E8B86;
-  --seat-1-soft: #E3ECF1;
-  --seat-2-soft: #ECF3EC;
-  --seat-3-soft: #F7EFE0;
-  --seat-4-soft: #EFEAF1;
-  --seat-5-soft: #E5F0EF;
+  --seat-1: #3f6c85;
+  --seat-2: #4c8a58;
+  --seat-3: #b68430;
+  --seat-4: #7c5a86;
+  --seat-5: #4e8b86;
+  --seat-1-soft: #e3ecf1;
+  --seat-2-soft: #ecf3ec;
+  --seat-3-soft: #f7efe0;
+  --seat-4-soft: #efeaf1;
+  --seat-5-soft: #e5f0ef;
 
   /* ── Semantic (muted, used rarely) ───────────────────────────────────── */
-  --success: #4C8A58;
-  --success-soft: #ECF3EC;
-  --warning: #B68430;
-  --warning-soft: #F7EFE0;
-  --danger: #B14B35;
-  --danger-soft: #F6E4DF;
-  --info: #3F6C85;
-  --info-soft: #E3ECF1;
+  --success: #4c8a58;
+  --success-soft: #ecf3ec;
+  --warning: #b68430;
+  --warning-soft: #f7efe0;
+  --danger: #b14b35;
+  --danger-soft: #f6e4df;
+  --info: #3f6c85;
+  --info-soft: #e3ecf1;
 
   /* ── Shadows / grid texture ──────────────────────────────────────────── */
-  --shadow-sm: 0 1px 2px 0 rgb(20 22 26 / .06);
-  --shadow-md: 0 4px 10px -2px rgb(20 22 26 / .08), 0 2px 4px -2px rgb(20 22 26 / .04);
-  --shadow-lg: 0 12px 28px -8px rgb(20 22 26 / .18), 0 4px 10px -4px rgb(20 22 26 / .08);
-  --grid: rgba(20, 22, 26, .022);
+  --shadow-sm: 0 1px 2px 0 rgb(20 22 26 / 0.06);
+  --shadow-md: 0 4px 10px -2px rgb(20 22 26 / 0.08), 0 2px 4px -2px rgb(20 22 26 / 0.04);
+  --shadow-lg: 0 12px 28px -8px rgb(20 22 26 / 0.18), 0 4px 10px -4px rgb(20 22 26 / 0.08);
+  --grid: rgba(20, 22, 26, 0.022);
 
   /* ── Typography ──────────────────────────────────────────────────────── */
-  --font-display: "Instrument Sans", ui-sans-serif, system-ui, sans-serif; /* UI + body */
-  --font-head: "Bricolage Grotesque", "Instrument Sans", ui-sans-serif, system-ui, sans-serif; /* headlines */
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; /* all numeric data */
+  --font-display: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif; /* UI + body */
+  --font-head:
+    'Bricolage Grotesque', 'Instrument Sans', ui-sans-serif, system-ui, sans-serif; /* headlines */
+  --font-mono:
+    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace; /* all numeric data */
 
   /* ── Motion ──────────────────────────────────────────────────────────── */
   --dur-micro: 120ms;
@@ -85,149 +87,103 @@
   --transition-fast: 120ms cubic-bezier(0.2, 0, 0, 1);
   --transition-medium: 180ms cubic-bezier(0.2, 0, 0, 1);
   --transition-slow: 240ms cubic-bezier(0.2, 0, 0, 1);
-
-  /* ── Transitional alias shim ─────────────────────────────────────────────
-   * Maps every legacy "Scholarly Deliberation Chamber" token onto the new
-   * tokens so unmigrated component CSS keeps building during the re-skin.
-   * Declared once here; dark mode auto-follows via lazy var() substitution.
-   * REMOVED in the final phase once all components reference new tokens.
-   * ──────────────────────────────────────────────────────────────────── */
-  --color-cream: var(--bg);
-  --color-ivory: var(--bg-raised);
-  --color-parchment: var(--bg-sunken);
-  --color-sage-light: var(--surface);
-  --color-sage: var(--surface-hover);
-
-  --color-burgundy: var(--accent);
-  --color-burgundy-dark: var(--accent-hover);
-  --color-burgundy-light: var(--accent);
-
-  --color-gold: var(--warning);
-  --color-gold-light: var(--warning-soft);
-  --color-gold-dark: var(--warning);
-
-  --color-stage1: var(--seat-1-soft);
-  --color-stage1-border: var(--seat-1);
-  --color-stage1-accent: var(--seat-1);
-  --color-stage2: var(--seat-3-soft);
-  --color-stage2-border: var(--seat-3);
-  --color-stage2-accent: var(--seat-3);
-  --color-stage3: var(--accent-soft);
-  --color-stage3-border: var(--accent);
-  --color-stage3-accent: var(--accent);
-
-  --color-text-primary: var(--fg);
-  --color-text-secondary: var(--fg-muted);
-  --color-text-muted: var(--fg-faint);
-
-  --color-border: var(--line);
-  --color-border-light: var(--line);
-  --color-surface: var(--bg-raised);
-  --color-surface-elevated: var(--bg-raised);
-  --color-error: var(--danger);
-
-  --shadow-subtle: var(--shadow-sm);
-  --shadow-medium: var(--shadow-md);
-  --shadow-elevated: var(--shadow-lg);
-
-  --font-body: var(--font-display);
 }
 
 /* Dark mode — the primary/default theme for this product.
  * Both blocks (explicit toggle + OS preference) carry identical dark values. */
-:root[data-theme="dark"] {
-  --bg: #1A1D23;
-  --bg-raised: #23262E;
-  --bg-sunken: #15171C;
-  --surface: #23262E;
-  --surface-hover: #2B2F38;
+:root[data-theme='dark'] {
+  --bg: #1a1d23;
+  --bg-raised: #23262e;
+  --bg-sunken: #15171c;
+  --surface: #23262e;
+  --surface-hover: #2b2f38;
 
-  --fg: #EEEFF2;
-  --fg-muted: #B5B9C2;
-  --fg-subtle: #868B96;
-  --fg-faint: #5E6370;
-  --fg-on-accent: #14161A;
+  --fg: #eeeff2;
+  --fg-muted: #b5b9c2;
+  --fg-subtle: #868b96;
+  --fg-faint: #5e6370;
+  --fg-on-accent: #14161a;
 
-  --line: #30343D;
-  --line-strong: #3C414B;
+  --line: #30343d;
+  --line-strong: #3c414b;
 
-  --accent: #E1865F;
-  --accent-hover: #EE9A78;
-  --accent-soft: #2A1C14;
-  --accent-ring: rgba(225, 134, 95, .45);
+  --accent: #e1865f;
+  --accent-hover: #ee9a78;
+  --accent-soft: #2a1c14;
+  --accent-ring: rgba(225, 134, 95, 0.45);
 
-  --seat-1: #68A0BC;
-  --seat-2: #71A77B;
-  --seat-3: #D0A150;
-  --seat-4: #A98AB4;
-  --seat-5: #6FB3AD;
-  --seat-1-soft: #13202A;
+  --seat-1: #68a0bc;
+  --seat-2: #71a77b;
+  --seat-3: #d0a150;
+  --seat-4: #a98ab4;
+  --seat-5: #6fb3ad;
+  --seat-1-soft: #13202a;
   --seat-2-soft: #152318;
-  --seat-3-soft: #241D10;
-  --seat-4-soft: #1F1824;
-  --seat-5-soft: #0F211F;
+  --seat-3-soft: #241d10;
+  --seat-4-soft: #1f1824;
+  --seat-5-soft: #0f211f;
 
-  --success: #71A77B;
-  --success-soft: #17241A;
-  --warning: #D0A150;
-  --warning-soft: #2A2113;
-  --danger: #D16A55;
-  --danger-soft: #2B1510;
-  --info: #68A0BC;
-  --info-soft: #11212B;
+  --success: #71a77b;
+  --success-soft: #17241a;
+  --warning: #d0a150;
+  --warning-soft: #2a2113;
+  --danger: #d16a55;
+  --danger-soft: #2b1510;
+  --info: #68a0bc;
+  --info-soft: #11212b;
 
-  --grid: rgba(255, 255, 255, .025);
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / .35);
-  --shadow-md: 0 4px 10px -2px rgb(0 0 0 / .45), 0 2px 4px -2px rgb(0 0 0 / .25);
-  --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / .6), 0 4px 10px -4px rgb(0 0 0 / .3);
+  --grid: rgba(255, 255, 255, 0.025);
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.35);
+  --shadow-md: 0 4px 10px -2px rgb(0 0 0 / 0.45), 0 2px 4px -2px rgb(0 0 0 / 0.25);
+  --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / 0.6), 0 4px 10px -4px rgb(0 0 0 / 0.3);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --bg: #1A1D23;
-    --bg-raised: #23262E;
-    --bg-sunken: #15171C;
-    --surface: #23262E;
-    --surface-hover: #2B2F38;
+  :root:not([data-theme='light']) {
+    --bg: #1a1d23;
+    --bg-raised: #23262e;
+    --bg-sunken: #15171c;
+    --surface: #23262e;
+    --surface-hover: #2b2f38;
 
-    --fg: #EEEFF2;
-    --fg-muted: #B5B9C2;
-    --fg-subtle: #868B96;
-    --fg-faint: #5E6370;
-    --fg-on-accent: #14161A;
+    --fg: #eeeff2;
+    --fg-muted: #b5b9c2;
+    --fg-subtle: #868b96;
+    --fg-faint: #5e6370;
+    --fg-on-accent: #14161a;
 
-    --line: #30343D;
-    --line-strong: #3C414B;
+    --line: #30343d;
+    --line-strong: #3c414b;
 
-    --accent: #E1865F;
-    --accent-hover: #EE9A78;
-    --accent-soft: #2A1C14;
-    --accent-ring: rgba(225, 134, 95, .45);
+    --accent: #e1865f;
+    --accent-hover: #ee9a78;
+    --accent-soft: #2a1c14;
+    --accent-ring: rgba(225, 134, 95, 0.45);
 
-    --seat-1: #68A0BC;
-    --seat-2: #71A77B;
-    --seat-3: #D0A150;
-    --seat-4: #A98AB4;
-    --seat-5: #6FB3AD;
-    --seat-1-soft: #13202A;
+    --seat-1: #68a0bc;
+    --seat-2: #71a77b;
+    --seat-3: #d0a150;
+    --seat-4: #a98ab4;
+    --seat-5: #6fb3ad;
+    --seat-1-soft: #13202a;
     --seat-2-soft: #152318;
-    --seat-3-soft: #241D10;
-    --seat-4-soft: #1F1824;
-    --seat-5-soft: #0F211F;
+    --seat-3-soft: #241d10;
+    --seat-4-soft: #1f1824;
+    --seat-5-soft: #0f211f;
 
-    --success: #71A77B;
-    --success-soft: #17241A;
-    --warning: #D0A150;
-    --warning-soft: #2A2113;
-    --danger: #D16A55;
-    --danger-soft: #2B1510;
-    --info: #68A0BC;
-    --info-soft: #11212B;
+    --success: #71a77b;
+    --success-soft: #17241a;
+    --warning: #d0a150;
+    --warning-soft: #2a2113;
+    --danger: #d16a55;
+    --danger-soft: #2b1510;
+    --info: #68a0bc;
+    --info-soft: #11212b;
 
-    --grid: rgba(255, 255, 255, .025);
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / .35);
-    --shadow-md: 0 4px 10px -2px rgb(0 0 0 / .45), 0 2px 4px -2px rgb(0 0 0 / .25);
-    --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / .6), 0 4px 10px -4px rgb(0 0 0 / .3);
+    --grid: rgba(255, 255, 255, 0.025);
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.35);
+    --shadow-md: 0 4px 10px -2px rgb(0 0 0 / 0.45), 0 2px 4px -2px rgb(0 0 0 / 0.25);
+    --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / 0.6), 0 4px 10px -4px rgb(0 0 0 / 0.3);
   }
 }
 
@@ -301,10 +257,18 @@ body {
   margin-top: 0;
 }
 
-.markdown-content h1 { font-size: 1.5rem; }
-.markdown-content h2 { font-size: 1.25rem; }
-.markdown-content h3 { font-size: 1.0625rem; }
-.markdown-content h4 { font-size: 1rem; }
+.markdown-content h1 {
+  font-size: 1.5rem;
+}
+.markdown-content h2 {
+  font-size: 1.25rem;
+}
+.markdown-content h3 {
+  font-size: 1.0625rem;
+}
+.markdown-content h4 {
+  font-size: 1rem;
+}
 
 .markdown-content ul,
 .markdown-content ol {
@@ -526,7 +490,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(0, 0, 0, .5);
+  background: rgba(0, 0, 0, 0.5);
   animation: ccFade var(--dur-standard) var(--ease-out);
 }
 
@@ -577,7 +541,9 @@ body {
   border-radius: 8px;
   color: var(--fg-subtle);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .cc-modal-close:hover {
@@ -602,18 +568,33 @@ body {
 
 /* ── Keyframes (applied with stagger in components; gated below) ───────── */
 @keyframes ccFade {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes ccBar {
-  from { transform: scaleX(0); }
-  to { transform: scaleX(1); }
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
 }
 
 @keyframes ccPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: .45; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
 }
 
 /* Respect reduced-motion everywhere. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,57 +1,72 @@
-/* LLM Council - Scholarly Deliberation Chamber Theme */
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Source+Serif+4:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap');
+/* LLM Council - "Deliberation Instrument" Theme
+ * Dark-first workshop-tool aesthetic. Per-model "seat" colors,
+ * ember orange for primary actions + the chairman's verdict, mono for all data.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
 :root {
-  /* Base Palette - Warm, Scholarly */
-  --color-cream: #FDFBF7;
-  --color-ivory: #F8F5EF;
-  --color-parchment: #F0EDE5;
-  --color-sage-light: #F0F5F3;
-  --color-sage: #E2EBE7;
+  /* ── Neutrals & surfaces (light) ─────────────────────────────────────── */
+  --bg: #EBEAE5;
+  --bg-raised: #F7F6F3;
+  --bg-sunken: #E3E2DC;
+  --surface: #FBFAF8;
+  --surface-hover: #EDECE7;
 
-  /* Primary - Deep Burgundy */
-  --color-burgundy: #8B2635;
-  --color-burgundy-dark: #6B1D2A;
-  --color-burgundy-light: #A83D4D;
+  --fg: #14161A;
+  --fg-muted: #363A42;
+  --fg-subtle: #6A6F7A;
+  --fg-faint: #8E939E;
+  --fg-on-accent: #FFFFFF;
 
-  /* Secondary - Warm Gold */
-  --color-gold: #C4A35A;
-  --color-gold-light: #E8D9B0;
-  --color-gold-dark: #9A7F42;
+  --line: #DBDAD2;
+  --line-strong: #C7C6BD;
 
-  /* Stage Colors */
-  --color-stage1: #E8EDF2;
-  --color-stage1-border: #C5D0DC;
-  --color-stage1-accent: #5B7A9D;
+  /* ── Accent — ember (primary CTAs, chairman synthesis/verdict, brand) ── */
+  --accent: #D76A3A;
+  --accent-hover: #BC5528;
+  --accent-soft: #FBEEE6;
+  --accent-ring: rgba(215, 106, 58, .4);
 
-  --color-stage2: #FDF6E3;
-  --color-stage2-border: #E8D9B0;
-  --color-stage2-accent: #9A7F42;
+  /* ── Seat / model identity palette (the signature) ───────────────────── */
+  --seat-1: #3F6C85;
+  --seat-2: #4C8A58;
+  --seat-3: #B68430;
+  --seat-4: #7C5A86;
+  --seat-5: #4E8B86;
+  --seat-1-soft: #E3ECF1;
+  --seat-2-soft: #ECF3EC;
+  --seat-3-soft: #F7EFE0;
+  --seat-4-soft: #EFEAF1;
+  --seat-5-soft: #E5F0EF;
 
-  --color-stage3: #E8F0E8;
-  --color-stage3-border: #B8D4B8;
-  --color-stage3-accent: #4A7C59;
+  /* ── Semantic (muted, used rarely) ───────────────────────────────────── */
+  --success: #4C8A58;
+  --success-soft: #ECF3EC;
+  --warning: #B68430;
+  --warning-soft: #F7EFE0;
+  --danger: #B14B35;
+  --danger-soft: #F6E4DF;
+  --info: #3F6C85;
+  --info-soft: #E3ECF1;
 
-  /* Text */
-  --color-text-primary: #2A2520;
-  --color-text-secondary: #5C5650;
-  --color-text-muted: #8A847C;
+  /* ── Shadows / grid texture ──────────────────────────────────────────── */
+  --shadow-sm: 0 1px 2px 0 rgb(20 22 26 / .06);
+  --shadow-md: 0 4px 10px -2px rgb(20 22 26 / .08), 0 2px 4px -2px rgb(20 22 26 / .04);
+  --shadow-lg: 0 12px 28px -8px rgb(20 22 26 / .18), 0 4px 10px -4px rgb(20 22 26 / .08);
+  --grid: rgba(20, 22, 26, .022);
 
-  /* Borders & Shadows */
-  --color-border: #DCD7CE;
-  --color-border-light: #E8E4DC;
-  --color-surface: #FFFFFF;
-  --color-surface-elevated: #FFFFFF;
-  --shadow-subtle: 0 1px 3px rgba(42, 37, 32, 0.06);
-  --shadow-medium: 0 4px 12px rgba(42, 37, 32, 0.08);
-  --shadow-elevated: 0 8px 24px rgba(42, 37, 32, 0.12);
+  /* ── Typography ──────────────────────────────────────────────────────── */
+  --font-display: "Instrument Sans", ui-sans-serif, system-ui, sans-serif; /* UI + body */
+  --font-head: "Bricolage Grotesque", "Instrument Sans", ui-sans-serif, system-ui, sans-serif; /* headlines */
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; /* all numeric data */
 
-  /* Typography */
-  --font-display: 'Playfair Display', Georgia, serif;
-  --font-body: 'Source Serif 4', Georgia, serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', monospace;
+  /* ── Motion ──────────────────────────────────────────────────────────── */
+  --dur-micro: 120ms;
+  --dur-standard: 180ms;
+  --dur-deliberate: 240ms;
+  --ease-out: cubic-bezier(0.2, 0, 0, 1);
 
-  /* Spacing */
+  /* ── Spacing (unchanged from prior theme) ────────────────────────────── */
   --space-xs: 4px;
   --space-sm: 8px;
   --space-md: 16px;
@@ -59,117 +74,161 @@
   --space-xl: 32px;
   --space-2xl: 48px;
 
-  /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-medium: 250ms ease;
-  --transition-slow: 400ms ease;
-
-  /* Radii */
-  --radius-sm: 4px;
-  --radius-md: 8px;
+  /* ── Radii ───────────────────────────────────────────────────────────── */
+  --radius-sm: 6px;
+  --radius-md: 9px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+  --radius-pill: 999px;
 
-  /* Additional shadows */
-  --shadow-lg: 0 10px 30px rgba(42, 37, 32, 0.15);
+  /* ── Transitions (duration + easing pairs) ───────────────────────────── */
+  --transition-fast: 120ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-medium: 180ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-slow: 240ms cubic-bezier(0.2, 0, 0, 1);
+
+  /* ── Transitional alias shim ─────────────────────────────────────────────
+   * Maps every legacy "Scholarly Deliberation Chamber" token onto the new
+   * tokens so unmigrated component CSS keeps building during the re-skin.
+   * Declared once here; dark mode auto-follows via lazy var() substitution.
+   * REMOVED in the final phase once all components reference new tokens.
+   * ──────────────────────────────────────────────────────────────────── */
+  --color-cream: var(--bg);
+  --color-ivory: var(--bg-raised);
+  --color-parchment: var(--bg-sunken);
+  --color-sage-light: var(--surface);
+  --color-sage: var(--surface-hover);
+
+  --color-burgundy: var(--accent);
+  --color-burgundy-dark: var(--accent-hover);
+  --color-burgundy-light: var(--accent);
+
+  --color-gold: var(--warning);
+  --color-gold-light: var(--warning-soft);
+  --color-gold-dark: var(--warning);
+
+  --color-stage1: var(--seat-1-soft);
+  --color-stage1-border: var(--seat-1);
+  --color-stage1-accent: var(--seat-1);
+  --color-stage2: var(--seat-3-soft);
+  --color-stage2-border: var(--seat-3);
+  --color-stage2-accent: var(--seat-3);
+  --color-stage3: var(--accent-soft);
+  --color-stage3-border: var(--accent);
+  --color-stage3-accent: var(--accent);
+
+  --color-text-primary: var(--fg);
+  --color-text-secondary: var(--fg-muted);
+  --color-text-muted: var(--fg-faint);
+
+  --color-border: var(--line);
+  --color-border-light: var(--line);
+  --color-surface: var(--bg-raised);
+  --color-surface-elevated: var(--bg-raised);
+  --color-error: var(--danger);
+
+  --shadow-subtle: var(--shadow-sm);
+  --shadow-medium: var(--shadow-md);
+  --shadow-elevated: var(--shadow-lg);
+
+  --font-body: var(--font-display);
 }
 
-/* Dark Mode - Scholarly Night Theme */
+/* Dark mode — the primary/default theme for this product.
+ * Both blocks (explicit toggle + OS preference) carry identical dark values. */
+:root[data-theme="dark"] {
+  --bg: #1A1D23;
+  --bg-raised: #23262E;
+  --bg-sunken: #15171C;
+  --surface: #23262E;
+  --surface-hover: #2B2F38;
+
+  --fg: #EEEFF2;
+  --fg-muted: #B5B9C2;
+  --fg-subtle: #868B96;
+  --fg-faint: #5E6370;
+  --fg-on-accent: #14161A;
+
+  --line: #30343D;
+  --line-strong: #3C414B;
+
+  --accent: #E1865F;
+  --accent-hover: #EE9A78;
+  --accent-soft: #2A1C14;
+  --accent-ring: rgba(225, 134, 95, .45);
+
+  --seat-1: #68A0BC;
+  --seat-2: #71A77B;
+  --seat-3: #D0A150;
+  --seat-4: #A98AB4;
+  --seat-5: #6FB3AD;
+  --seat-1-soft: #13202A;
+  --seat-2-soft: #152318;
+  --seat-3-soft: #241D10;
+  --seat-4-soft: #1F1824;
+  --seat-5-soft: #0F211F;
+
+  --success: #71A77B;
+  --success-soft: #17241A;
+  --warning: #D0A150;
+  --warning-soft: #2A2113;
+  --danger: #D16A55;
+  --danger-soft: #2B1510;
+  --info: #68A0BC;
+  --info-soft: #11212B;
+
+  --grid: rgba(255, 255, 255, .025);
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / .35);
+  --shadow-md: 0 4px 10px -2px rgb(0 0 0 / .45), 0 2px 4px -2px rgb(0 0 0 / .25);
+  --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / .6), 0 4px 10px -4px rgb(0 0 0 / .3);
+}
+
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    /* Base Palette - Deep, Warm Darks */
-    --color-cream: #18171a;
-    --color-ivory: #1e1d21;
-    --color-parchment: #252428;
-    --color-sage-light: #1c1e1d;
-    --color-sage: #232625;
-    --color-surface: #2a292e;
-    --color-surface-elevated: #323136;
+    --bg: #1A1D23;
+    --bg-raised: #23262E;
+    --bg-sunken: #15171C;
+    --surface: #23262E;
+    --surface-hover: #2B2F38;
 
-    /* Primary - Brighter Burgundy for Dark */
-    --color-burgundy: #E07A8E;
-    --color-burgundy-dark: #C95A6E;
-    --color-burgundy-light: #F09AAE;
+    --fg: #EEEFF2;
+    --fg-muted: #B5B9C2;
+    --fg-subtle: #868B96;
+    --fg-faint: #5E6370;
+    --fg-on-accent: #14161A;
 
-    /* Secondary - Warm Gold (brighter for dark) */
-    --color-gold: #E5C87A;
-    --color-gold-light: #3D3528;
-    --color-gold-dark: #D4B86A;
+    --line: #30343D;
+    --line-strong: #3C414B;
 
-    /* Stage Colors - Darker variants with better contrast */
-    --color-stage1: #1E2430;
-    --color-stage1-border: #3A4860;
-    --color-stage1-accent: #8AADD4;
+    --accent: #E1865F;
+    --accent-hover: #EE9A78;
+    --accent-soft: #2A1C14;
+    --accent-ring: rgba(225, 134, 95, .45);
 
-    --color-stage2: #2A2518;
-    --color-stage2-border: #4A4230;
-    --color-stage2-accent: #E5C87A;
+    --seat-1: #68A0BC;
+    --seat-2: #71A77B;
+    --seat-3: #D0A150;
+    --seat-4: #A98AB4;
+    --seat-5: #6FB3AD;
+    --seat-1-soft: #13202A;
+    --seat-2-soft: #152318;
+    --seat-3-soft: #241D10;
+    --seat-4-soft: #1F1824;
+    --seat-5-soft: #0F211F;
 
-    --color-stage3: #1E2A1E;
-    --color-stage3-border: #3A5840;
-    --color-stage3-accent: #7AB889;
+    --success: #71A77B;
+    --success-soft: #17241A;
+    --warning: #D0A150;
+    --warning-soft: #2A2113;
+    --danger: #D16A55;
+    --danger-soft: #2B1510;
+    --info: #68A0BC;
+    --info-soft: #11212B;
 
-    /* Text - Better contrast for readability */
-    --color-text-primary: #F0EDE8;
-    --color-text-secondary: #C0B8AC;
-    --color-text-muted: #908880;
-
-    /* Borders & Shadows */
-    --color-border: #3E3A36;
-    --color-border-light: #2E2A26;
-    --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.3);
-    --shadow-medium: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-elevated: 0 8px 24px rgba(0, 0, 0, 0.5);
-    --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.6);
+    --grid: rgba(255, 255, 255, .025);
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / .35);
+    --shadow-md: 0 4px 10px -2px rgb(0 0 0 / .45), 0 2px 4px -2px rgb(0 0 0 / .25);
+    --shadow-lg: 0 12px 28px -8px rgb(0 0 0 / .6), 0 4px 10px -4px rgb(0 0 0 / .3);
   }
-}
-
-/* Manual dark theme override */
-:root[data-theme="dark"] {
-  /* Base Palette - Deep, Warm Darks */
-  --color-cream: #18171a;
-  --color-ivory: #1e1d21;
-  --color-parchment: #252428;
-  --color-sage-light: #1c1e1d;
-  --color-sage: #232625;
-  --color-surface: #2a292e;
-  --color-surface-elevated: #323136;
-
-  /* Primary - Brighter Burgundy for Dark */
-  --color-burgundy: #E07A8E;
-  --color-burgundy-dark: #C95A6E;
-  --color-burgundy-light: #F09AAE;
-
-  /* Secondary - Warm Gold (brighter for dark) */
-  --color-gold: #E5C87A;
-  --color-gold-light: #3D3528;
-  --color-gold-dark: #D4B86A;
-
-  /* Stage Colors - Darker variants with better contrast */
-  --color-stage1: #1E2430;
-  --color-stage1-border: #3A4860;
-  --color-stage1-accent: #8AADD4;
-
-  --color-stage2: #2A2518;
-  --color-stage2-border: #4A4230;
-  --color-stage2-accent: #E5C87A;
-
-  --color-stage3: #1E2A1E;
-  --color-stage3-border: #3A5840;
-  --color-stage3-accent: #7AB889;
-
-  /* Text - Better contrast for readability */
-  --color-text-primary: #F0EDE8;
-  --color-text-secondary: #C0B8AC;
-  --color-text-muted: #908880;
-
-  /* Borders & Shadows */
-  --color-border: #3E3A36;
-  --color-border-light: #2E2A26;
-  --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.3);
-  --shadow-medium: 0 4px 12px rgba(0, 0, 0, 0.4);
-  --shadow-elevated: 0 8px 24px rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.6);
 }
 
 * {
@@ -186,11 +245,12 @@ html {
 }
 
 body {
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-weight: 400;
   line-height: 1.6;
-  color: var(--color-text-primary);
-  background: var(--color-cream);
+  letter-spacing: -0.005em;
+  color: var(--fg);
+  background: var(--bg);
   min-width: 320px;
   min-height: 100vh;
 }
@@ -201,29 +261,17 @@ body {
   overflow: hidden;
 }
 
-/* Subtle paper texture overlay */
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-  opacity: 0.015;
-  pointer-events: none;
-  z-index: 9999;
-}
-
-/* Global markdown styling */
+/* ── Global markdown styling ──────────────────────────────────────────── */
 .markdown-content {
   padding: var(--space-md);
-  font-family: var(--font-body);
-  line-height: 1.7;
+  font-family: var(--font-display);
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
 }
 
 .markdown-content p {
-  margin: 0 0 var(--space-md) 0;
+  margin: 0 0 11px 0;
 }
 
 .markdown-content p:last-child {
@@ -236,10 +284,11 @@ body::before {
 .markdown-content h4,
 .markdown-content h5,
 .markdown-content h6 {
-  font-family: var(--font-display);
+  font-family: var(--font-head);
   font-weight: 600;
+  letter-spacing: -0.02em;
   margin: var(--space-lg) 0 var(--space-md) 0;
-  color: var(--color-text-primary);
+  color: var(--fg);
   line-height: 1.3;
 }
 
@@ -268,21 +317,21 @@ body::before {
 }
 
 .markdown-content pre {
-  background: var(--color-parchment);
+  background: var(--bg-sunken);
   padding: var(--space-md);
   border-radius: var(--radius-md);
   overflow-x: auto;
   margin: 0 0 var(--space-md) 0;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--line);
 }
 
 .markdown-content code {
   font-family: var(--font-mono);
-  background: var(--color-parchment);
+  background: var(--bg-sunken);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   font-size: 0.875em;
-  color: var(--color-burgundy);
+  color: var(--accent);
 }
 
 .markdown-content pre code {
@@ -294,27 +343,26 @@ body::before {
 .markdown-content blockquote {
   margin: 0 0 var(--space-md) 0;
   padding: var(--space-md) var(--space-lg);
-  border-left: 4px solid var(--color-burgundy);
-  background: var(--color-ivory);
+  border-left: 3px solid var(--accent);
+  background: var(--bg-sunken);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
-  color: var(--color-text-secondary);
-  font-style: italic;
+  color: var(--fg-subtle);
 }
 
 .markdown-content strong {
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--fg);
 }
 
 .markdown-content a {
-  color: var(--color-burgundy);
+  color: var(--accent);
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: color var(--transition-fast);
 }
 
 .markdown-content a:hover {
-  color: var(--color-burgundy-dark);
+  color: var(--accent-hover);
 }
 
 .markdown-content table {
@@ -326,143 +374,109 @@ body::before {
 
 .markdown-content th,
 .markdown-content td {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--line);
   padding: var(--space-sm) var(--space-md);
   text-align: left;
 }
 
 .markdown-content th {
-  background: var(--color-parchment);
+  background: var(--bg-sunken);
   font-weight: 600;
   font-family: var(--font-display);
 }
 
 .markdown-content tr:nth-child(even) {
-  background: var(--color-ivory);
+  background: var(--surface-hover);
 }
 
-/* Custom scrollbar */
+/* ── Custom scrollbar ─────────────────────────────────────────────────── */
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--color-parchment);
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
-  border-radius: 5px;
-  border: 2px solid var(--color-parchment);
+  background: var(--line-strong);
+  border-radius: 6px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-muted);
+  background: var(--fg-faint);
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }
 
-/* Focus styles */
+/* ── Focus + selection ────────────────────────────────────────────────── */
 :focus-visible {
-  outline: 2px solid var(--color-burgundy);
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
-/* Selection */
 ::selection {
-  background: var(--color-gold-light);
-  color: var(--color-text-primary);
+  background: var(--accent-soft);
+  color: var(--fg);
 }
 
-/* ========================================
-   Unified Tab Component Styles
-   ========================================
-   These styles provide consistent tab behavior
-   across all stage components. Individual stages
-   can override accent colors via CSS variables.
-   ======================================== */
-
+/* ========================================================================
+   Shared tab primitives
+   Active tab = 2px bottom border in the active model's seat color, set by
+   the consumer via --tab-accent-color. Inactive tabs = --fg-subtle.
+   ======================================================================== */
 .tabs {
   display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-md);
+  gap: 4px;
   flex-wrap: wrap;
-  padding-bottom: var(--space-sm);
-  border-bottom: 1px solid var(--tab-border-color, var(--color-border));
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--tab-border-color, var(--line));
 }
 
 .tab {
-  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 12px 11px 12px;
+  margin-bottom: -1px;
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--fg-subtle);
   cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 0.8125rem;
+  font-family: var(--font-display);
+  font-size: 12.5px;
   font-weight: 500;
+  white-space: nowrap;
   transition:
-    background var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast),
-    transform 0.15s ease;
-  position: relative;
+    color var(--dur-standard) var(--ease-out),
+    border-color var(--dur-standard) var(--ease-out);
 }
 
 .tab:hover {
-  background: var(--color-surface-elevated);
-  color: var(--color-text-primary);
+  color: var(--fg);
 }
 
 .tab:focus-visible {
-  outline: 2px solid var(--tab-accent-color, var(--color-burgundy));
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
 }
 
 .tab.active {
-  background: var(--color-surface);
-  color: var(--tab-accent-color, var(--color-burgundy));
-  border-color: var(--tab-border-color, var(--color-border));
-  box-shadow: var(--shadow-subtle);
+  color: var(--fg);
+  font-weight: 600;
+  border-bottom-color: var(--tab-accent-color, var(--accent));
 }
 
-/* Tab underline indicator animation */
-.tab::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 50%;
-  width: 0;
-  height: 2px;
-  background: var(--tab-accent-color, var(--color-burgundy));
-  transition: width 0.2s ease, left 0.2s ease;
-}
-
-.tab.active::after {
-  width: 100%;
-  left: 0;
-}
-
-/* Tab content panel */
+/* Tab content panel — cross-fades on switch (gated by reduced-motion). */
 .tab-content {
-  background: var(--color-surface);
-  padding: var(--space-lg);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--tab-border-color, var(--color-border));
-  box-shadow: var(--shadow-subtle);
-  animation: tabContentFade 0.2s ease-out;
+  padding: 20px 22px;
+  animation: ccFade var(--dur-standard) var(--ease-out);
   -webkit-backface-visibility: hidden;
-}
-
-@keyframes tabContentFade {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .tab-content-header {
@@ -472,29 +486,146 @@ body::before {
   margin-bottom: var(--space-md);
 }
 
-/* Copy button - shared style */
+/* Copy button — shared style */
 .copy-btn {
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--color-ivory);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  cursor: pointer;
+  color: var(--fg-subtle);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .copy-btn:hover {
-  background: var(--color-parchment);
-  border-color: var(--tab-accent-color, var(--color-burgundy));
-  color: var(--tab-accent-color, var(--color-burgundy));
+  background: var(--surface-hover);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .copy-btn:focus-visible {
-  outline: 2px solid var(--tab-accent-color, var(--color-burgundy));
+  outline: 2px solid var(--accent-ring);
   outline-offset: 2px;
+}
+
+/* ========================================================================
+   Shared modal chrome — consumed by ModelSelector + ModelCuration
+   ======================================================================== */
+.cc-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, .5);
+  animation: ccFade var(--dur-standard) var(--ease-out);
+}
+
+.cc-modal-panel {
+  width: 600px;
+  max-width: 100%;
+  max-height: 84vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-raised);
+  border: 1px solid var(--line-strong);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.cc-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 22px 16px 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.cc-modal-title {
+  font-family: var(--font-head);
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+}
+
+.cc-modal-subtitle {
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+  color: var(--fg-subtle);
+}
+
+.cc-modal-close {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.cc-modal-close:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.cc-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 22px 18px 22px;
+}
+
+.cc-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 22px;
+  border-top: 1px solid var(--line);
+  background: var(--bg-sunken);
+}
+
+/* ── Keyframes (applied with stagger in components; gated below) ───────── */
+@keyframes ccFade {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ccBar {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+
+@keyframes ccPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .45; }
+}
+
+/* Respect reduced-motion everywhere. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Screen reader only utility */

--- a/frontend/src/lib/seatColors.js
+++ b/frontend/src/lib/seatColors.js
@@ -1,0 +1,93 @@
+/**
+ * Seat-color assignment — the signature of the "Deliberation Instrument" theme.
+ *
+ * Each council model carries a persistent "seat" color (one of 5 curated
+ * swatches) that follows it everywhere: avatar, opinion tab, peer-review row,
+ * standings bar. Assignment is a pure function of the council *set*:
+ *
+ *   - Deterministic + stable across sessions: the seat derives from a hash of
+ *     the model id, never from random state or insertion order.
+ *   - Stable across council reordering: ids are resolved in a canonical order
+ *     (by hash, then id), so reordering the roster never reshuffles colors.
+ *   - Collision-nudged: a council of <=5 models stays visually distinct — when
+ *     two ids hash to the same seat, later ones probe forward to a free seat.
+ *   - Beyond 5 models every seat is in use, so repeats are allowed at the raw
+ *     hashed seat.
+ */
+
+export const SEAT_COUNT = 5;
+
+/**
+ * Deterministic 32-bit FNV-1a hash of a string -> unsigned int32.
+ * @param {string} str
+ * @returns {number}
+ */
+export function hashString(str) {
+  let h = 0x811c9dc5;
+  const s = String(str);
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Token bundle for a 1-based seat number.
+ * @param {number} seat - 1..SEAT_COUNT
+ * @returns {{ seat: number, color: string, soft: string }}
+ */
+export function seatTokens(seat) {
+  return {
+    seat,
+    color: `var(--seat-${seat})`,
+    soft: `var(--seat-${seat}-soft)`,
+  };
+}
+
+/**
+ * Raw hashed seat (1..SEAT_COUNT) for an id, ignoring collisions.
+ * @param {string} id
+ * @returns {number}
+ */
+export function rawSeat(id) {
+  return (hashString(id) % SEAT_COUNT) + 1;
+}
+
+/**
+ * Assign a stable seat to each council model.
+ * @param {string[]} councilIds
+ * @returns {Map<string, { seat: number, color: string, soft: string }>}
+ */
+export function assignSeats(councilIds = []) {
+  const ids = (Array.isArray(councilIds) ? councilIds : []).filter((id) => id != null).map(String);
+
+  // Dedupe (assignment is set-based); first occurrence wins.
+  const unique = [...new Set(ids)];
+
+  // Canonical order: by hash, then id. Order-independent so reordering the
+  // roster never changes any model's color.
+  const ordered = [...unique].sort((a, b) => {
+    const ha = hashString(a);
+    const hb = hashString(b);
+    if (ha !== hb) return ha - hb;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+
+  const map = new Map();
+  const taken = new Set(); // seat indices 0..SEAT_COUNT-1 currently in use
+
+  for (const id of ordered) {
+    const start = hashString(id) % SEAT_COUNT;
+    let idx = start;
+    if (taken.size < SEAT_COUNT) {
+      // Linear probe forward to keep a council of <=5 visually distinct.
+      while (taken.has(idx)) idx = (idx + 1) % SEAT_COUNT;
+      taken.add(idx);
+    }
+    // else: every seat is in use -> keep the raw hashed seat (repeats allowed).
+    map.set(id, seatTokens(idx + 1));
+  }
+
+  return map;
+}


### PR DESCRIPTION
## Summary

Replaces the "Scholarly Deliberation Chamber" theme (burgundy / gold / cream, Playfair
Display serif) with **"Deliberation Instrument"** — a quiet, dark-first, workshop-tool
aesthetic. The signature idea is a **persistent per-model "seat" color** that follows each
council model everywhere (avatar, opinion tab, peer-review row, standings bar), with **ember
orange** reserved for true primary actions and the chairman's synthesis/verdict, and **all
numeric data set in monospace**.

This is primarily a styling + layout pass over the existing architecture — no data-flow or
backend changes — plus one genuinely new piece: the seat-color system.

## What changed

**Foundation (`index.css`)**
- New token system: neutrals/surfaces, ember accent, 5 seat colors (+ soft variants), muted
  semantics, crisp shadows, a near-invisible dot-grid, and motion tokens. Light + both dark
  blocks kept in sync; dark is the default theme.
- Fonts: Bricolage Grotesque (headlines), Instrument Sans (UI/body), JetBrains Mono (all data).
- Restyled focus ring, selection, scrollbar, markdown, shared tab + modal primitives, motion
  keyframes, and a `prefers-reduced-motion` guard.

**Seat-color system (new)**
- `lib/seatColors.js` — deterministic hash into one of 5 curated seats; set-based and
  collision-nudged so a council of ≤5 stays visually distinct and reordering the roster never
  reshuffles colors. Unit-tested.
- `useSeatColors()` hook + shared UI primitives: `SeatAvatar`, `BrandMark`, `StageRail`,
  `ToggleSwitch`, `KpiCard`.

**Components re-skinned**
- Sidebar (brand mark + two-tone wordmark, ember New-deliberation CTA, Council/Arena segmented
  control, footer nav + synced dot + 3-state theme chip).
- ChatInterface (dark-first landing, stage scaffolding with the stage rail + STAGE-N tags,
  sticky ask-bar, persistent topbar with mode badge + title + council seat avatars + export).
- Round (seat-underlined Stage-1 tabs with arrow-key nav, Stage-2 seat-color ranking bars,
  Arena 2-column FOR/AGAINST cards).
- Synthesis (ember-bordered verdict card with crown header + copy/fork/re-synthesize).
- ModelSelector / ModelCuration / model groups (shared modal chrome, provider groups, per-row
  toggle + chairman crown, seat-soft selected rows).
- Standings (headline + KPI strip + leaderboard from real metrics; seat-color rating bars;
  trend chart in seat colors).
- MetricsDisplay / ModelErrors / SkeletonLoader / VersionInfo.
- Unicode glyphs → `lucide-react` icons throughout.

**Motion**
- Deliberation blocks stagger in; ranking/standings bars grow; Stage-1 tab switches cross-fade —
  all gated by `prefers-reduced-motion`.

## Notes / decisions

- **Standings is frontend-only.** KPIs and the leaderboard are built strictly from metrics
  already tracked (rating / games / last seen). No win-rate, per-model spend, or latency
  aggregates were invented — that would be backend work, deliberately out of scope.
- **Seat assignment is set-based**, so it stays stable across sessions and across council
  reordering, while staying distinct for a council of ≤5.
- The existing 3-state system/light/dark theme toggle is preserved.

## Verification

- `npm run build` clean; `npm test` 178/178 pass (including the new seat-color suite).
- A repo-wide check confirms no legacy theme tokens, fonts, or hardcoded colors remain.
- Lint is unchanged from the base branch: 8 pre-existing errors (unused vars / a
  setState-in-effect) that predate this work.

A live visual pass in both light and dark is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation export options for Markdown and JSON.
  * Introduced a refreshed dark-first theme with updated colors, typography, and seat-based accents.
  * Added improved council/arena visuals, including seat avatars, stage progress, and KPI cards.

* **Bug Fixes**
  * Conversation and model selection now behave more consistently on mobile and after creation.
  * Loading, empty, and error states were refined for clearer feedback.
  * Reduced-motion handling and scrolling behavior were improved for smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->